### PR TITLE
Provide codec config schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/miniconda3
+
 /target
 /Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ postcard = { version = "1.0", default-features = false }
 pyo3 = { version = "0.21", default-features = false }
 pythonize = { version = "0.21", default-features = false }
 rand = { version = "0.8", default-features = false }
-schemars = { version = "1.0.0-alpha.3", default-features = false }
+schemars = { version = "=1.0.0-alpha.9", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde-transcode = { version = "1.1", default-features = false }
 serde_json = { version = "1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ postcard = { version = "1.0", default-features = false }
 pyo3 = { version = "0.21", default-features = false }
 pythonize = { version = "0.21", default-features = false }
 rand = { version = "0.8", default-features = false }
+schemars = { version = "1.0.0-alpha.3", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde-transcode = { version = "1.1", default-features = false }
 serde_json = { version = "1.0", default-features = false }

--- a/codecs/bit-round/Cargo.toml
+++ b/codecs/bit-round/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["bit-rounding", "numcodecs", "compression", "encoding"]
 [dependencies]
 ndarray = { workspace = true }
 numcodecs = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -19,8 +19,8 @@
 
 use ndarray::{Array, ArrayBase, Data, Dimension};
 use numcodecs::{
-    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, Codec, StaticCodec, StaticCodecConfig,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    Codec, StaticCodec, StaticCodecConfig,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,7 @@ impl StaticCodec for BitRoundCodec {
 
     type Config<'de> = Self;
 
-    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+    fn from_config(config: Self::Config<'_>) -> Self {
         config
     }
 

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -28,7 +28,15 @@ use thiserror::Error;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-/// Codec providing floating-point [`bit_round`]ing.
+/// Codec providing floating-point bit rounding.
+///
+/// Drops the specified number of bits from the floating point mantissa,
+/// leaving an array that is more amenable to compression. The number of
+/// bits to keep should be determined by information analysis of the data
+/// to be compressed.
+///
+/// The approach is based on the paper by Klöwer et al. 2021
+/// (<https://www.nature.com/articles/s43588-021-00156-2>).
 pub struct BitRoundCodec {
     /// The number of bits of the mantissa to keep.
     ///
@@ -108,15 +116,8 @@ pub enum BitRoundCodecError {
     },
 }
 
-/// Floating-point bit rounding.
-///
-/// Drops the specified number of bits from the floating point mantissa,
-/// leaving an array that is more amenable to compression. The number of
-/// bits to keep should be determined by information analysis of the data
-/// to be compressed.
-///
-/// The approach is based on the paper by Klöwer et al. 2021
-/// (<https://www.nature.com/articles/s43588-021-00156-2>).
+/// Floating-point bit rounding, which drops the specified number of bits from
+/// the floating point mantissa.
 ///
 /// See <https://github.com/milankl/BitInformation.jl> for the the original
 /// implementation in Julia.

--- a/codecs/identity/Cargo.toml
+++ b/codecs/identity/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["identity", "numcodecs", "compression", "encoding"]
 
 [dependencies]
 numcodecs = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 

--- a/codecs/identity/src/lib.rs
+++ b/codecs/identity/src/lib.rs
@@ -18,8 +18,8 @@
 //! Identity codec implementation for the [`numcodecs`] API.
 
 use numcodecs::{
-    AnyArray, AnyArrayAssignError, AnyArrayView, AnyArrayViewMut,
-    AnyCowArray, Codec, StaticCodec, StaticCodecConfig,
+    AnyArray, AnyArrayAssignError, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, StaticCodec,
+    StaticCodecConfig,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ impl StaticCodec for IdentityCodec {
 
     type Config<'de> = Self;
 
-    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+    fn from_config(config: Self::Config<'_>) -> Self {
         config
     }
 

--- a/codecs/linear-quantize/Cargo.toml
+++ b/codecs/linear-quantize/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["linear", "quantization", "numcodecs", "compression", "encoding"]
 ndarray = { workspace = true, features = ["std"] }
 numcodecs = { workspace = true }
 postcard = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_repr = { workspace = true }
 thiserror = { workspace = true }

--- a/codecs/linear-quantize/src/lib.rs
+++ b/codecs/linear-quantize/src/lib.rs
@@ -23,15 +23,17 @@ use std::{borrow::Cow, fmt};
 
 use ndarray::{Array, Array1, ArrayBase, ArrayD, ArrayViewMutD, Data, Dimension, ShapeError};
 use numcodecs::{
-    serialize_codec_config_with_id, AnyArray, AnyArrayDType, AnyArrayView, AnyArrayViewMut,
-    AnyCowArray, Codec, StaticCodec,
+    AnyArray, AnyArrayDType, AnyArrayView, AnyArrayViewMut,
+    AnyCowArray, Codec, StaticCodec, StaticCodecConfig,
 };
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+use schemars::JsonSchema;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
 use twofloat::TwoFloat;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 /// Lossy codec to reduce the precision of floating point data.
 ///
 /// The data is quantized to unsigned integers of the best-fitting type.
@@ -44,7 +46,8 @@ pub struct LinearQuantizeCodec {
 }
 
 /// Data types which the [`LinearQuantizeCodec`] can quantize
-#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(extend("enum" = ["f32", "float32", "f64", "float64"]))]
 #[allow(missing_docs)]
 pub enum LinearQuantizeDType {
     #[serde(rename = "f32", alias = "float32")]
@@ -67,7 +70,7 @@ impl fmt::Display for LinearQuantizeDType {
 /// The binary `#[repr(u8)]` value of each variant is equivalent to the binary
 /// logarithm of the number of bins, i.e. the binary precision or the number of
 /// bits used.
-#[derive(Copy, Clone, Serialize_repr, Deserialize_repr)]
+#[derive(Copy, Clone, Serialize_repr, Deserialize_repr, schemars::JsonSchema_repr)]
 #[repr(u8)]
 #[rustfmt::skip]
 #[allow(missing_docs)]
@@ -382,17 +385,19 @@ impl Codec for LinearQuantizeCodec {
 
         Ok(())
     }
-
-    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serialize_codec_config_with_id(self, self, serializer)
-    }
 }
 
 impl StaticCodec for LinearQuantizeCodec {
     const CODEC_ID: &'static str = "linear-quantize";
 
-    fn from_config<'de, D: Deserializer<'de>>(config: D) -> Result<Self, D::Error> {
-        Self::deserialize(config)
+    type Config<'de> = Self;
+
+    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+        config
+    }
+
+    fn get_config(&self) -> StaticCodecConfig<Self> {
+        StaticCodecConfig::from(self)
     }
 }
 

--- a/codecs/linear-quantize/src/lib.rs
+++ b/codecs/linear-quantize/src/lib.rs
@@ -23,10 +23,10 @@ use std::{borrow::Cow, fmt};
 
 use ndarray::{Array, Array1, ArrayBase, ArrayD, ArrayViewMutD, Data, Dimension, ShapeError};
 use numcodecs::{
-    AnyArray, AnyArrayDType, AnyArrayView, AnyArrayViewMut,
-    AnyCowArray, Codec, StaticCodec, StaticCodecConfig,
+    AnyArray, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, StaticCodec,
+    StaticCodecConfig,
 };
-use schemars::JsonSchema;
+use schemars::{JsonSchema, JsonSchema_repr};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
@@ -46,7 +46,7 @@ pub struct LinearQuantizeCodec {
 }
 
 /// Data types which the [`LinearQuantizeCodec`] can quantize
-#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("enum" = ["f32", "float32", "f64", "float64"]))]
 #[allow(missing_docs)]
 pub enum LinearQuantizeDType {
@@ -70,7 +70,7 @@ impl fmt::Display for LinearQuantizeDType {
 /// The binary `#[repr(u8)]` value of each variant is equivalent to the binary
 /// logarithm of the number of bins, i.e. the binary precision or the number of
 /// bits used.
-#[derive(Copy, Clone, Serialize_repr, Deserialize_repr, schemars::JsonSchema_repr)]
+#[derive(Copy, Clone, Serialize_repr, Deserialize_repr, JsonSchema_repr)]
 #[repr(u8)]
 #[rustfmt::skip]
 #[allow(missing_docs)]
@@ -392,7 +392,7 @@ impl StaticCodec for LinearQuantizeCodec {
 
     type Config<'de> = Self;
 
-    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+    fn from_config(config: Self::Config<'_>) -> Self {
         config
     }
 
@@ -719,7 +719,7 @@ impl Unsigned for u64 {
     const ZERO: Self = 0;
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
 struct CompressionHeader<'a, T: Float> {
     #[serde(borrow)]

--- a/codecs/log/Cargo.toml
+++ b/codecs/log/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["log", "numcodecs", "compression", "encoding"]
 [dependencies]
 ndarray = { workspace = true }
 numcodecs = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 

--- a/codecs/log/src/lib.rs
+++ b/codecs/log/src/lib.rs
@@ -19,8 +19,8 @@
 
 use ndarray::{Array, ArrayBase, ArrayView, ArrayViewMut, Data, Dimension};
 use numcodecs::{
-    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, Codec, StaticCodec, StaticCodecConfig,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    Codec, StaticCodec, StaticCodecConfig,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -85,7 +85,7 @@ impl StaticCodec for LogCodec {
 
     type Config<'de> = Self;
 
-    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+    fn from_config(config: Self::Config<'_>) -> Self {
         config
     }
 

--- a/codecs/reinterpret/Cargo.toml
+++ b/codecs/reinterpret/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["reinterpret", "numcodecs", "compression", "encoding"]
 [dependencies]
 ndarray = { workspace = true }
 numcodecs = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -19,8 +19,8 @@
 
 use ndarray::{Array, ArrayBase, ArrayView, Data, DataMut, Dimension, ViewRepr};
 use numcodecs::{
-    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, ArrayDType, Codec, StaticCodec, StaticCodecConfig,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    ArrayDType, Codec, StaticCodec, StaticCodecConfig,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -298,7 +298,7 @@ impl StaticCodec for ReinterpretCodec {
 
     type Config<'de> = Self;
 
-    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+    fn from_config(config: Self::Config<'_>) -> Self {
         config
     }
 

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -31,8 +31,13 @@ use thiserror::Error;
 /// Codec to reinterpret data between different compatible types.
 ///
 /// Note that no conversion happens, only the meaning of the bits changes.
+///
+/// Reinterpreting to bytes, or to a same-sized unsigned integer type, or
+/// without the changing the dtype are supported.
 pub struct ReinterpretCodec {
+    /// Dtype of the encoded data.
     encode_dtype: AnyArrayDType,
+    /// Dtype of the decoded data
     decode_dtype: AnyArrayDType,
 }
 

--- a/codecs/round/Cargo.toml
+++ b/codecs/round/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["round", "numcodecs", "compression", "encoding"]
 [dependencies]
 ndarray = { workspace = true }
 numcodecs = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 

--- a/codecs/round/src/lib.rs
+++ b/codecs/round/src/lib.rs
@@ -17,18 +17,22 @@
 //!
 //! Rounding codec implementation for the [`numcodecs`] API.
 
-use std::ops::{Div, Mul};
+use std::{
+    borrow::Cow,
+    ops::{Div, Mul},
+};
 
 use ndarray::{Array, ArrayBase, Data, Dimension};
 use numcodecs::{
-    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, Codec, StaticCodec, StaticCodecConfig,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    Codec, StaticCodec, StaticCodecConfig,
 };
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 /// Codec that [`round`]s the data on encoding and passes through the input
 /// unchanged during decoding.
 ///
@@ -79,7 +83,7 @@ impl StaticCodec for RoundCodec {
 
     type Config<'de> = Self;
 
-    fn from_config<'de>(config: Self::Config<'de>) -> Self {
+    fn from_config(config: Self::Config<'_>) -> Self {
         config
     }
 
@@ -93,14 +97,14 @@ impl StaticCodec for RoundCodec {
 /// Positive floating point number
 pub struct Positive<T: Float>(T);
 
-impl serde::Serialize for Positive<f64> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl Serialize for Positive<f64> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_f64(self.0)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Positive<f64> {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+impl<'de> Deserialize<'de> for Positive<f64> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let x = f64::deserialize(deserializer)?;
 
         if x > 0.0 {
@@ -111,6 +115,23 @@ impl<'de> serde::Deserialize<'de> for Positive<f64> {
                 &"a positive value",
             ))
         }
+    }
+}
+
+impl JsonSchema for Positive<f64> {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("PositiveF64")
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed(concat!(module_path!(), "::", "Positive<f64>"))
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "number",
+            "exclusiveMinimum": 0.0
+        })
     }
 }
 

--- a/codecs/sz3/Cargo.toml
+++ b/codecs/sz3/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["sz3", "numcodecs", "compression", "encoding"]
 ndarray = { workspace = true, features = ["std"] }
 numcodecs = { workspace = true }
 postcard = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 sz3 = { workspace = true }
 thiserror = { workspace = true }

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -31,7 +31,17 @@ use thiserror::Error;
 // sz3-sys/Sz3-sys
 use ::zstd_sys as _;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[cfg(test)]
+mod tests2 {
+    #[test]
+    fn schema() {
+        let schema = schemars::schema_for!(super::Sz3Codec);
+        panic!("{:#}", schema.to_value());
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 /// Codec providing compression using SZ3
 pub struct Sz3Codec {
     /// SZ3 error bound
@@ -40,7 +50,7 @@ pub struct Sz3Codec {
 }
 
 /// SZ3 error bound
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(tag = "eb_mode")]
 #[serde(deny_unknown_fields)]
 pub enum Sz3ErrorBound {
@@ -445,60 +455,60 @@ impl fmt::Display for Sz3DType {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use ndarray::ArrayView1;
+// #[cfg(test)]
+// mod tests {
+//     use ndarray::ArrayView1;
 
-    use super::*;
+//     use super::*;
 
-    #[test]
-    fn zero_length() -> Result<(), Sz3CodecError> {
-        let encoded = compress(
-            Array::<f32, _>::from_shape_vec([1, 27, 0].as_slice(), vec![])?,
-            &Sz3ErrorBound::L2Norm { l2: 27.0 },
-        )?;
-        let decoded = decompress(&encoded)?;
+//     #[test]
+//     fn zero_length() -> Result<(), Sz3CodecError> {
+//         let encoded = compress(
+//             Array::<f32, _>::from_shape_vec([1, 27, 0].as_slice(), vec![])?,
+//             &Sz3ErrorBound::L2Norm { l2: 27.0 },
+//         )?;
+//         let decoded = decompress(&encoded)?;
 
-        assert_eq!(decoded.dtype(), AnyArrayDType::F32);
-        assert!(decoded.is_empty());
-        assert_eq!(decoded.shape(), &[1, 27, 0]);
+//         assert_eq!(decoded.dtype(), AnyArrayDType::F32);
+//         assert!(decoded.is_empty());
+//         assert_eq!(decoded.shape(), &[1, 27, 0]);
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    #[test]
-    fn one_dimension() -> Result<(), Sz3CodecError> {
-        let data = Array::from_shape_vec([2_usize, 1, 2, 1].as_slice(), vec![1, 2, 3, 4])?;
+//     #[test]
+//     fn one_dimension() -> Result<(), Sz3CodecError> {
+//         let data = Array::from_shape_vec([2_usize, 1, 2, 1].as_slice(), vec![1, 2, 3, 4])?;
 
-        let encoded = compress(data.view(), &Sz3ErrorBound::Absolute { abs: 0.0 })?;
-        let decoded = decompress(&encoded)?;
+//         let encoded = compress(data.view(), &Sz3ErrorBound::Absolute { abs: 0.0 })?;
+//         let decoded = decompress(&encoded)?;
 
-        assert_eq!(decoded, AnyArray::I32(data));
+//         assert_eq!(decoded, AnyArray::I32(data));
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    #[test]
-    fn small_state() -> Result<(), Sz3CodecError> {
-        for data in [
-            &[][..],
-            &[0.0],
-            &[0.0, 1.0],
-            &[0.0, 1.0, 0.0],
-            &[0.0, 1.0, 0.0, 1.0],
-        ] {
-            let encoded = compress(
-                ArrayView1::from(data),
-                &Sz3ErrorBound::Absolute { abs: 0.0 },
-            )?;
-            let decoded = decompress(&encoded)?;
+//     #[test]
+//     fn small_state() -> Result<(), Sz3CodecError> {
+//         for data in [
+//             &[][..],
+//             &[0.0],
+//             &[0.0, 1.0],
+//             &[0.0, 1.0, 0.0],
+//             &[0.0, 1.0, 0.0, 1.0],
+//         ] {
+//             let encoded = compress(
+//                 ArrayView1::from(data),
+//                 &Sz3ErrorBound::Absolute { abs: 0.0 },
+//             )?;
+//             let decoded = decompress(&encoded)?;
 
-            assert_eq!(
-                decoded,
-                AnyArray::F64(Array1::from_vec(data.to_vec()).into_dyn())
-            );
-        }
+//             assert_eq!(
+//                 decoded,
+//                 AnyArray::F64(Array1::from_vec(data.to_vec()).into_dyn())
+//             );
+//         }
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -449,60 +449,60 @@ impl fmt::Display for Sz3DType {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use ndarray::ArrayView1;
+#[cfg(test)]
+mod tests {
+    use ndarray::ArrayView1;
 
-//     use super::*;
+    use super::*;
 
-//     #[test]
-//     fn zero_length() -> Result<(), Sz3CodecError> {
-//         let encoded = compress(
-//             Array::<f32, _>::from_shape_vec([1, 27, 0].as_slice(), vec![])?,
-//             &Sz3ErrorBound::L2Norm { l2: 27.0 },
-//         )?;
-//         let decoded = decompress(&encoded)?;
+    #[test]
+    fn zero_length() -> Result<(), Sz3CodecError> {
+        let encoded = compress(
+            Array::<f32, _>::from_shape_vec([1, 27, 0].as_slice(), vec![])?,
+            &Sz3ErrorBound::L2Norm { l2: 27.0 },
+        )?;
+        let decoded = decompress(&encoded)?;
 
-//         assert_eq!(decoded.dtype(), AnyArrayDType::F32);
-//         assert!(decoded.is_empty());
-//         assert_eq!(decoded.shape(), &[1, 27, 0]);
+        assert_eq!(decoded.dtype(), AnyArrayDType::F32);
+        assert!(decoded.is_empty());
+        assert_eq!(decoded.shape(), &[1, 27, 0]);
 
-//         Ok(())
-//     }
+        Ok(())
+    }
 
-//     #[test]
-//     fn one_dimension() -> Result<(), Sz3CodecError> {
-//         let data = Array::from_shape_vec([2_usize, 1, 2, 1].as_slice(), vec![1, 2, 3, 4])?;
+    #[test]
+    fn one_dimension() -> Result<(), Sz3CodecError> {
+        let data = Array::from_shape_vec([2_usize, 1, 2, 1].as_slice(), vec![1, 2, 3, 4])?;
 
-//         let encoded = compress(data.view(), &Sz3ErrorBound::Absolute { abs: 0.0 })?;
-//         let decoded = decompress(&encoded)?;
+        let encoded = compress(data.view(), &Sz3ErrorBound::Absolute { abs: 0.0 })?;
+        let decoded = decompress(&encoded)?;
 
-//         assert_eq!(decoded, AnyArray::I32(data));
+        assert_eq!(decoded, AnyArray::I32(data));
 
-//         Ok(())
-//     }
+        Ok(())
+    }
 
-//     #[test]
-//     fn small_state() -> Result<(), Sz3CodecError> {
-//         for data in [
-//             &[][..],
-//             &[0.0],
-//             &[0.0, 1.0],
-//             &[0.0, 1.0, 0.0],
-//             &[0.0, 1.0, 0.0, 1.0],
-//         ] {
-//             let encoded = compress(
-//                 ArrayView1::from(data),
-//                 &Sz3ErrorBound::Absolute { abs: 0.0 },
-//             )?;
-//             let decoded = decompress(&encoded)?;
+    #[test]
+    fn small_state() -> Result<(), Sz3CodecError> {
+        for data in [
+            &[][..],
+            &[0.0],
+            &[0.0, 1.0],
+            &[0.0, 1.0, 0.0],
+            &[0.0, 1.0, 0.0, 1.0],
+        ] {
+            let encoded = compress(
+                ArrayView1::from(data),
+                &Sz3ErrorBound::Absolute { abs: 0.0 },
+            )?;
+            let decoded = decompress(&encoded)?;
 
-//             assert_eq!(
-//                 decoded,
-//                 AnyArray::F64(Array1::from_vec(data.to_vec()).into_dyn())
-//             );
-//         }
+            assert_eq!(
+                decoded,
+                AnyArray::F64(Array1::from_vec(data.to_vec()).into_dyn())
+            );
+        }
 
-//         Ok(())
-//     }
-// }
+        Ok(())
+    }
+}

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -33,11 +33,10 @@ use thiserror::Error;
 use ::zstd_sys as _;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
+#[serde(transparent)]
 /// Codec providing compression using SZ3
 pub struct Sz3Codec {
     /// SZ3 error bound
-    #[serde(flatten)]
     pub error: Sz3ErrorBound,
 }
 

--- a/codecs/uniform-noise/Cargo.toml
+++ b/codecs/uniform-noise/Cargo.toml
@@ -19,6 +19,7 @@ ndarray = { workspace = true }
 numcodecs = { workspace = true }
 rand = { workspace = true }
 wyhash = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -35,9 +35,14 @@ use wyhash::{WyHash, WyRng};
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-/// Codec that adds `seed`ed uniform noise of the given `scale` and with
-/// [`add_uniform_noise`] during encoding and passes through the input unchanged
-/// during decoding.
+/// Codec that adds `seed`ed `U(-scale/2, scale/2)` uniform noise of the given
+/// `scale` during encoding and passes through the input unchanged during
+/// decoding.
+///
+/// This codec first hashes the input array data and shape to then seed a
+/// pseudo-random number generator that generates the uniform noise. Therefore,
+/// passing in the same input with the same `seed` will produce the same noise
+/// and thus the same encoded output.
 pub struct UniformNoiseCodec {
     /// Scale of the uniform noise, which is sampled from
     /// `U(-scale/2, +scale/2)`

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -21,18 +21,20 @@ use std::hash::{Hash, Hasher};
 
 use ndarray::{Array, ArrayBase, Data, Dimension};
 use numcodecs::{
-    serialize_codec_config_with_id, AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, Codec, StaticCodec,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    Codec, StaticCodec, StaticCodecConfig,
 };
 use rand::{
     distributions::{Distribution, Open01},
     SeedableRng,
 };
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wyhash::{WyHash, WyRng};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 /// Codec that adds `seed`ed uniform noise of the given `scale` and with
 /// [`add_uniform_noise`] during encoding and passes through the input unchanged
 /// during decoding.
@@ -81,17 +83,19 @@ impl Codec for UniformNoiseCodec {
 
         Ok(decoded.assign(&encoded)?)
     }
-
-    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serialize_codec_config_with_id(self, self, serializer)
-    }
 }
 
 impl StaticCodec for UniformNoiseCodec {
     const CODEC_ID: &'static str = "uniform-noise";
 
-    fn from_config<'de, D: Deserializer<'de>>(config: D) -> Result<Self, D::Error> {
-        Self::deserialize(config)
+    type Config<'de> = Self;
+
+    fn from_config(config: Self::Config<'_>) -> Self {
+        config
+    }
+
+    fn get_config(&self) -> StaticCodecConfig<Self> {
+        StaticCodecConfig::from(self)
     }
 }
 

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["zfp", "numcodecs", "compression", "encoding"]
 [dependencies]
 ndarray = { workspace = true }
 numcodecs = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 zfp-sys = { workspace = true, features = ["static"] }

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -19,15 +19,17 @@
 
 use ndarray::{Array1, ArrayView, Dimension};
 use numcodecs::{
-    serialize_codec_config_with_id, AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, Codec, StaticCodec,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    Codec, StaticCodec, StaticCodecConfig,
 };
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 mod ffi;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 /// Codec providing compression using ZFP
 pub struct ZfpCodec {
     /// ZFP compression mode
@@ -35,7 +37,7 @@ pub struct ZfpCodec {
     pub mode: ZfpCompressionMode,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "mode")]
 #[serde(deny_unknown_fields)]
 /// ZFP compression mode
@@ -151,17 +153,19 @@ impl Codec for ZfpCodec {
 
         decompress_into(&AnyArrayView::U8(encoded).as_bytes(), decoded)
     }
-
-    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serialize_codec_config_with_id(self, self, serializer)
-    }
 }
 
 impl StaticCodec for ZfpCodec {
     const CODEC_ID: &'static str = "zfp";
 
-    fn from_config<'de, D: Deserializer<'de>>(config: D) -> Result<Self, D::Error> {
-        Self::deserialize(config)
+    type Config<'de> = Self;
+
+    fn from_config(config: Self::Config<'_>) -> Self {
+        config
+    }
+
+    fn get_config(&self) -> StaticCodecConfig<Self> {
+        StaticCodecConfig::from(self)
     }
 }
 

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -29,11 +29,10 @@ use thiserror::Error;
 mod ffi;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
+#[serde(transparent)]
 /// Codec providing compression using ZFP
 pub struct ZfpCodec {
     /// ZFP compression mode
-    #[serde(flatten)]
     pub mode: ZfpCompressionMode,
 }
 

--- a/codecs/zlib/Cargo.toml
+++ b/codecs/zlib/Cargo.toml
@@ -19,6 +19,7 @@ ndarray = { workspace = true }
 numcodecs = { workspace = true }
 miniz_oxide = { workspace = true, features = ["std", "with-alloc"] }
 postcard = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_repr = { workspace = true }
 thiserror = { workspace = true }

--- a/codecs/zlib/src/lib.rs
+++ b/codecs/zlib/src/lib.rs
@@ -33,7 +33,9 @@ use thiserror::Error;
 #[serde(deny_unknown_fields)]
 /// Codec providing compression using Zlib
 pub struct ZlibCodec {
-    /// Compression level
+    /// Zlib compression level.
+    ///
+    /// The level ranges from 0, no compression, to 9, best compression.
     pub level: ZlibLevel,
 }
 

--- a/codecs/zstd/Cargo.toml
+++ b/codecs/zstd/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["zstd", "numcodecs", "compression", "encoding"]
 ndarray = { workspace = true }
 numcodecs = { workspace = true }
 postcard = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 zstd = { workspace = true }

--- a/codecs/zstd/src/lib.rs
+++ b/codecs/zstd/src/lib.rs
@@ -35,7 +35,9 @@ use thiserror::Error;
 #[serde(deny_unknown_fields)]
 /// Codec providing compression using Zstandard
 pub struct ZstdCodec {
-    /// Compression level
+    /// Zstandard compression level.
+    ///
+    /// The level ranges from small (fastest) to large (best compression).
     pub level: ZstdLevel,
 }
 

--- a/codecs/zstd/src/lib.rs
+++ b/codecs/zstd/src/lib.rs
@@ -17,6 +17,7 @@
 //!
 //! Zstandard codec implementation for the [`numcodecs`] API.
 
+use schemars::JsonSchema;
 // Only used to explicitly enable the `no_wasm_shim` feature in zstd/zstd-sys
 use zstd_sys as _;
 
@@ -24,13 +25,14 @@ use std::{borrow::Cow, io};
 
 use ndarray::Array1;
 use numcodecs::{
-    serialize_codec_config_with_id, AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView,
-    AnyArrayViewMut, AnyCowArray, Codec, StaticCodec,
+    AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
+    Codec, StaticCodec, StaticCodecConfig,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 /// Codec providing compression using Zstandard
 pub struct ZstdCodec {
     /// Compression level
@@ -80,21 +82,24 @@ impl Codec for ZstdCodec {
 
         decompress_into(&AnyArrayView::U8(encoded).as_bytes(), decoded)
     }
-
-    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serialize_codec_config_with_id(self, self, serializer)
-    }
 }
 
 impl StaticCodec for ZstdCodec {
     const CODEC_ID: &'static str = "zstd";
 
-    fn from_config<'de, D: Deserializer<'de>>(config: D) -> Result<Self, D::Error> {
-        Self::deserialize(config)
+    type Config<'de> = Self;
+
+    fn from_config(config: Self::Config<'_>) -> Self {
+        config
+    }
+
+    fn get_config(&self) -> StaticCodecConfig<Self> {
+        StaticCodecConfig::from(self)
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, JsonSchema)]
+#[schemars(transparent)]
 /// Zstandard compression level.
 ///
 /// The level ranges from small (fastest) to large (best compression).
@@ -102,15 +107,15 @@ pub struct ZstdLevel {
     level: zstd::zstd_safe::CompressionLevel,
 }
 
-impl serde::Serialize for ZstdLevel {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl Serialize for ZstdLevel {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.level.serialize(serializer)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for ZstdLevel {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let level = serde::Deserialize::deserialize(deserializer)?;
+impl<'de> Deserialize<'de> for ZstdLevel {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let level = Deserialize::deserialize(deserializer)?;
 
         let level_range = zstd::compression_level_range();
 
@@ -318,7 +323,7 @@ fn decompress_into_bytes(mut encoded: &[u8], mut decoded: &mut [u8]) -> Result<(
     Ok(())
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct CompressionHeader<'a> {
     dtype: AnyArrayDType,
     #[serde(borrow)]

--- a/crates/numcodecs-python/Cargo.toml
+++ b/crates/numcodecs-python/Cargo.toml
@@ -21,13 +21,13 @@ numcodecs = { workspace = true }
 numpy = { workspace = true }
 pyo3 = { workspace = true }
 pythonize = { workspace = true }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true }
 serde-transcode = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 pyo3 = { workspace = true, features = ["auto-initialize"] }
-schemars = { workspace = true, features = ["derive", "preserve_order"] }
-serde_json = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true

--- a/crates/numcodecs-python/Cargo.toml
+++ b/crates/numcodecs-python/Cargo.toml
@@ -26,6 +26,7 @@ serde-transcode = { workspace = true }
 
 [dev-dependencies]
 pyo3 = { workspace = true, features = ["auto-initialize"] }
+schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde_json = { workspace = true, features = ["std"] }
 
 [lints]

--- a/crates/numcodecs-python/Cargo.toml
+++ b/crates/numcodecs-python/Cargo.toml
@@ -25,6 +25,7 @@ schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true }
 serde-transcode = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 pyo3 = { workspace = true, features = ["auto-initialize"] }

--- a/crates/numcodecs-python/src/adapter.rs
+++ b/crates/numcodecs-python/src/adapter.rs
@@ -115,7 +115,7 @@ impl PyCodecAdapter {
         })
     }
 
-    /// If `codec` represents an exported [`DynCodec`] `T`, i.e. it's class was
+    /// If `codec` represents an exported [`DynCodec`] `T`, i.e. its class was
     /// initially created with [`crate::export_codec_class`], the `with` closure
     /// provides access to the instance of type `T`.
     ///
@@ -477,7 +477,7 @@ impl PyCodecClassAdapter {
         class: &Bound<PyCodecClass>,
         with: impl for<'a> FnOnce(&'a T) -> O,
     ) -> Option<O> {
-        let Ok(ty) = class.getattr(intern!(class.py(), "_ty")) else {
+        let Ok(ty) = class.getattr(intern!(class.py(), RustCodec::TYPE_ATTRIBUTE)) else {
             return None;
         };
 

--- a/crates/numcodecs-python/src/adapter.rs
+++ b/crates/numcodecs-python/src/adapter.rs
@@ -509,21 +509,21 @@ impl DynCodecType for PyCodecClassAdapter {
                     );
                     schema.insert(String::from("properties"), Value::Object(properties));
                     schema.insert(String::from("required"), Value::Array(required));
-
-                    if let Ok(doc) = init.getattr(intern!(py, "__doc__")) {
-                        if !doc.is_none() {
-                            let doc: String = doc.extract().expect("Python __doc__ must be a str");
-
-                            schema.insert(String::from("description"), Value::String(doc));
-                        }
-                    }
                 } else {
                     schema.insert(String::from("additionalProperties"), Value::Bool(true));
                 }
 
-                let title =
-                    convert_case::Casing::to_case(&*self.codec_id, convert_case::Case::Pascal);
-                schema.insert(String::from("title"), Value::String(title));
+                if let Ok(doc) = class.getattr(intern!(py, "__doc__")) {
+                    if !doc.is_none() {
+                        let doc: String = doc.extract().expect("Python __doc__ must be a str");
+
+                        schema.insert(String::from("description"), Value::String(doc));
+                    }
+                }
+
+                let name = (|| class.getattr(intern!(py, "__name__"))?.extract())()
+                    .expect("Python class must have a str __name__");
+                schema.insert(String::from("title"), Value::String(name));
 
                 schema.insert(
                     String::from("$schema"),

--- a/crates/numcodecs-python/src/adapter.rs
+++ b/crates/numcodecs-python/src/adapter.rs
@@ -156,21 +156,6 @@ impl Codec for PyCodecAdapter {
             Self::copy_into_any_array_view_mut_from_ndarray_like(py, &mut decoded, decoded_out)
         })
     }
-
-    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        Python::with_gil(|py| {
-            let config = self
-                .codec
-                .bind(py)
-                .get_config()
-                .map_err(serde::ser::Error::custom)?;
-
-            transcode(
-                &mut Depythonizer::from_object_bound(config.into_any()),
-                serializer,
-            )
-        })
-    }
 }
 
 impl PyCodecAdapter {
@@ -388,6 +373,21 @@ impl DynCodec for PyCodecAdapter {
         Python::with_gil(|py| PyCodecClassAdapter {
             class: self.class.clone_ref(py),
             codec_id: self.codec_id.clone(),
+        })
+    }
+
+    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Python::with_gil(|py| {
+            let config = self
+                .codec
+                .bind(py)
+                .get_config()
+                .map_err(serde::ser::Error::custom)?;
+
+            transcode(
+                &mut Depythonizer::from_object_bound(config.into_any()),
+                serializer,
+            )
         })
     }
 }

--- a/crates/numcodecs-python/src/adapter.rs
+++ b/crates/numcodecs-python/src/adapter.rs
@@ -436,6 +436,7 @@ impl DynCodecType for PyCodecClassAdapter {
         &self.codec_id
     }
 
+    #[allow(clippy::expect_used)]
     fn codec_config_schema(&self) -> Schema {
         Python::with_gil(|py| {
             let class = self.class.bind(py);
@@ -468,6 +469,7 @@ impl DynCodecType for PyCodecClassAdapter {
                             .getattr(intern!(py, "signature"))?
                             .call1((&init,))?
                             .getattr(intern!(py, "parameters"))?
+                            .call_method0(intern!(py, "items"))?
                             .iter()?
                             .enumerate()
                         {

--- a/crates/numcodecs-python/src/adapter.rs
+++ b/crates/numcodecs-python/src/adapter.rs
@@ -511,9 +511,11 @@ impl DynCodecType for PyCodecClassAdapter {
                     schema.insert(String::from("required"), Value::Array(required));
 
                     if let Ok(doc) = init.getattr(intern!(py, "__doc__")) {
-                        let doc: String = doc.extract().expect("Python __doc__ must be a str");
+                        if !doc.is_none() {
+                            let doc: String = doc.extract().expect("Python __doc__ must be a str");
 
-                        schema.insert(String::from("description"), Value::String(doc));
+                            schema.insert(String::from("description"), Value::String(doc));
+                        }
                     }
                 } else {
                     schema.insert(String::from("additionalProperties"), Value::Bool(true));

--- a/crates/numcodecs-python/src/codec_class.rs
+++ b/crates/numcodecs-python/src/codec_class.rs
@@ -38,6 +38,9 @@ pub trait PyCodecClassMethods<'py>: Sealed {
         &self,
         config: Borrowed<'_, 'py, PyDict>,
     ) -> Result<Bound<'py, PyCodec>, PyErr>;
+
+    /// Gets the [`PyType`] that this [`PyCodecClass`] represents.
+    fn as_type(&self) -> &Bound<'py, PyType>;
 }
 
 impl<'py> PyCodecClassMethods<'py> for Bound<'py, PyCodecClass> {
@@ -58,6 +61,14 @@ impl<'py> PyCodecClassMethods<'py> for Bound<'py, PyCodecClass> {
         self.as_any()
             .call_method1(intern!(py, "from_config"), (config,))?
             .extract()
+    }
+
+    fn as_type(&self) -> &Bound<'py, PyType> {
+        #[allow(unsafe_code)]
+        // Safety: PyCodecClass is a wrapper around PyType
+        unsafe {
+            self.downcast_unchecked()
+        }
     }
 }
 

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -89,6 +89,7 @@ pub fn export_codec_class<'py, T: DynCodecType>(
     Ok(codec_class)
 }
 
+#[allow(clippy::redundant_pub_crate)]
 #[pyclass(frozen)]
 pub(crate) struct RustCodecType {
     ty: Box<dyn 'static + Send + Sync + AnyCodecType>,
@@ -163,6 +164,7 @@ impl<T: DynCodecType> AnyCodecType for T {
     }
 }
 
+#[allow(clippy::redundant_pub_crate)]
 #[pyclass(subclass, frozen)]
 pub(crate) struct RustCodec {
     cls_module: String,

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -56,7 +56,7 @@ pub fn export_codec_class<'py, T: DynCodecType>(
                     docs_from_schema(&codec_config_schema, &codec_id).to_object(py).into_bound(py),
                 ),
                 (
-                    intern!(py, "_ty"),
+                    intern!(py, RustCodec::TYPE_ATTRIBUTE),
                     Bound::new(py, RustCodecType { ty: Box::new(ty) })?.into_any(),
                 ),
                 (
@@ -64,7 +64,7 @@ pub fn export_codec_class<'py, T: DynCodecType>(
                     PyString::new_bound(py, &codec_id).into_any(),
                 ),
                 (
-                    intern!(py, "__schema__"),
+                    intern!(py, RustCodec::SCHEMA_ATTRIBUTE),
                     pythonize(py, &codec_config_schema)?.into_bound(py),
                 ),
                 (
@@ -173,6 +173,9 @@ pub(crate) struct RustCodec {
 }
 
 impl RustCodec {
+    pub const SCHEMA_ATTRIBUTE: &'static str = "__schema__";
+    pub const TYPE_ATTRIBUTE: &'static str = "_ty";
+
     pub fn downcast<T: DynCodec>(&self) -> Option<&T> {
         self.codec.as_any().downcast_ref()
     }
@@ -193,7 +196,7 @@ impl RustCodec {
         let cls_name: String = cls.getattr(intern!(py, "__name__"))?.extract()?;
 
         let ty: Bound<RustCodecType> = cls
-            .getattr(intern!(py, "_ty"))
+            .getattr(intern!(py, RustCodec::TYPE_ATTRIBUTE))
             .map_err(|_| {
                 PyValueError::new_err(format!(
                     "{cls_module}.{cls_name} is not linked to a Rust codec type"

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -1,5 +1,7 @@
 use ndarray::{ArrayViewD, ArrayViewMutD, CowArray};
-use numcodecs::{AnyArray, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, DynCodecType};
+use numcodecs::{
+    AnyArray, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, DynCodec, DynCodecType,
+};
 use numpy::{
     IxDyn, PyArray, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyUntypedArray,
     PyUntypedArrayMethods,
@@ -82,7 +84,7 @@ trait AnyCodec {
     fn get_config<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>, PyErr>;
 }
 
-impl<T: Codec> AnyCodec for T {
+impl<T: DynCodec> AnyCodec for T {
     fn encode(&self, data: AnyCowArray) -> Result<AnyArray, PyErr> {
         <T as Codec>::encode(self, data).map_err(|err| PyRuntimeError::new_err(format!("{err}")))
     }
@@ -97,7 +99,7 @@ impl<T: Codec> AnyCodec for T {
     }
 
     fn get_config<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>, PyErr> {
-        <T as Codec>::get_config(self, Pythonizer::new(py))?.extract(py)
+        <T as DynCodec>::get_config(self, Pythonizer::new(py))?.extract(py)
     }
 }
 

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -18,7 +18,8 @@ use pyo3::{
 use pythonize::{pythonize, Depythonizer, Pythonizer};
 
 use crate::{
-    schema::docs_from_schema, PyCodec, PyCodecClass, PyCodecClassAdapter, PyCodecRegistry,
+    schema::{docs_from_schema, signature_from_schema},
+    PyCodec, PyCodecClass, PyCodecClassAdapter, PyCodecRegistry,
 };
 
 /// Export the [`DynCodecType`] `ty` to Python by generating a fresh
@@ -66,10 +67,13 @@ pub fn export_codec_class<'py, T: DynCodecType>(
                     intern!(py, "__schema__"),
                     pythonize(py, &codec_config_schema)?.into_bound(py),
                 ),
-                // (
-                //     intern!(py, "__init__"),
-                //     py.eval_bound(&format!("lambda self, {signature}: None"), None, None)?,
-                // ),
+                (
+                    intern!(py, "__init__"),
+                    py.eval_bound(&format!(
+                        "lambda {}: None",
+                        signature_from_schema(&codec_config_schema),
+                    ), None, None)?,
+                ),
             ]
             .into_py_dict_bound(py);
 

--- a/crates/numcodecs-python/src/lib.rs
+++ b/crates/numcodecs-python/src/lib.rs
@@ -28,6 +28,7 @@ mod codec;
 mod codec_class;
 mod export;
 mod registry;
+mod schema;
 
 pub use adapter::{PyCodecAdapter, PyCodecClassAdapter};
 pub use codec::{PyCodec, PyCodecMethods};

--- a/crates/numcodecs-python/src/schema.rs
+++ b/crates/numcodecs-python/src/schema.rs
@@ -9,7 +9,7 @@ use schemars::Schema;
 use serde_json::{Map, Value};
 use thiserror::Error;
 
-use crate::PyCodecClass;
+use crate::{export::RustCodec, PyCodecClass};
 
 macro_rules! once {
     ($py:ident, $module:literal $(, $path:literal)*) => {{
@@ -31,7 +31,7 @@ pub fn schema_from_codec_class(
     py: Python,
     class: &Bound<PyCodecClass>,
 ) -> Result<Schema, SchemaError> {
-    if let Ok(schema) = class.getattr(intern!(py, "__schema__")) {
+    if let Ok(schema) = class.getattr(intern!(py, RustCodec::SCHEMA_ATTRIBUTE)) {
         return depythonize_bound(schema)
             .map_err(|err| SchemaError::InvalidCachedJsonSchema { source: err });
     }
@@ -385,7 +385,7 @@ fn parameters_from_schema(schema: &Schema) -> Parameters {
 
 #[derive(Debug, Error)]
 pub enum SchemaError {
-    #[error("codec class' `__schema__` is invalid")]
+    #[error("codec class' cached config schema is invalid")]
     InvalidCachedJsonSchema { source: PythonizeError },
     #[error("extracting the codec signature failed")]
     SignatureExtraction {

--- a/crates/numcodecs-python/src/schema.rs
+++ b/crates/numcodecs-python/src/schema.rs
@@ -205,7 +205,7 @@ pub fn signature_from_schema(schema: &Schema) -> String {
         signature.push_str(parameter.name);
 
         if let Some(default) = parameter.default {
-            signature.push_str("=");
+            signature.push('=');
             signature.push_str(&format!("{default}"));
         } else if !parameter.required {
             signature.push_str("=None");

--- a/crates/numcodecs-python/src/schema.rs
+++ b/crates/numcodecs-python/src/schema.rs
@@ -1,0 +1,148 @@
+use pyo3::{intern, prelude::*, sync::GILOnceCell};
+use pythonize::{depythonize_bound, PythonizeError};
+use schemars::Schema;
+use serde_json::{Map, Value};
+use thiserror::Error;
+
+use crate::PyCodecClass;
+
+macro_rules! once {
+    ($py:ident, $module:literal $(, $path:literal)*) => {{
+        fn once(py: Python) -> Result<&Bound<PyAny>, PyErr> {
+            static ONCE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+            Ok(ONCE.get_or_try_init(py, || -> Result<Py<PyAny>, PyErr> {
+                Ok(py
+                    .import_bound(intern!(py, $module))?
+                    $(.getattr(intern!(py, $path))?)*
+                    .unbind())
+            })?.bind(py))
+        }
+
+        once($py)
+    }};
+}
+
+pub fn schema_from_codec_class(
+    py: Python,
+    class: &Bound<PyCodecClass>,
+) -> Result<Schema, SchemaError> {
+    if let Ok(schema) = class.getattr(intern!(py, "__schema__")) {
+        return depythonize_bound(schema)
+            .map_err(|err| SchemaError::InvalidCachedJsonSchema { source: err });
+    }
+
+    let mut schema = Schema::default();
+
+    {
+        let schema = schema.ensure_object();
+
+        schema.insert(String::from("type"), Value::String(String::from("object")));
+
+        if let Ok(init) = class.getattr(intern!(py, "__init__")) {
+            let mut properties = Map::new();
+            let mut additional_properties = false;
+            let mut required = Vec::new();
+
+            let object_init = once!(py, "builtins", "object", "__init__")?;
+            let signature = once!(py, "inspect", "signature")?;
+            let empty_parameter = once!(py, "inspect", "Parameter", "empty")?;
+            let args_parameter = once!(py, "inspect", "Parameter", "VAR_POSITIONAL")?;
+            let kwargs_parameter = once!(py, "inspect", "Parameter", "VAR_KEYWORD")?;
+
+            for (i, param) in signature
+                .call1((&init,))?
+                .getattr(intern!(py, "parameters"))?
+                .call_method0(intern!(py, "items"))?
+                .iter()?
+                .enumerate()
+            {
+                let (name, param): (String, Bound<PyAny>) = param?.extract()?;
+
+                if i == 0 && name == "self" {
+                    continue;
+                }
+
+                let kind = param.getattr(intern!(py, "kind"))?;
+
+                if kind.eq(args_parameter)? && !init.eq(object_init)? {
+                    return Err(SchemaError::ArgsParameterInSignature);
+                }
+
+                if kind.eq(kwargs_parameter)? {
+                    additional_properties = true;
+                } else {
+                    let default = param.getattr(intern!(py, "default"))?;
+
+                    let mut parameter = Map::new();
+
+                    if default.eq(empty_parameter)? {
+                        required.push(Value::String(name.clone()));
+                    } else {
+                        let default = depythonize_bound(default).map_err(|err| {
+                            SchemaError::InvalidParameterDefault {
+                                name: name.clone(),
+                                source: err,
+                            }
+                        })?;
+                        parameter.insert(String::from("default"), default);
+                    }
+
+                    properties.insert(name, Value::Object(parameter));
+                }
+            }
+
+            schema.insert(
+                String::from("additionalProperties"),
+                Value::Bool(additional_properties),
+            );
+            schema.insert(String::from("properties"), Value::Object(properties));
+            schema.insert(String::from("required"), Value::Array(required));
+        } else {
+            schema.insert(String::from("additionalProperties"), Value::Bool(true));
+        }
+
+        if let Ok(doc) = class.getattr(intern!(py, "__doc__")) {
+            if !doc.is_none() {
+                let doc: String = doc
+                    .extract()
+                    .map_err(|err| SchemaError::InvalidClassDocs { source: err })?;
+                schema.insert(String::from("description"), Value::String(doc));
+            }
+        }
+
+        let name = class
+            .getattr(intern!(py, "__name__"))
+            .and_then(|name| name.extract())
+            .map_err(|err| SchemaError::InvalidClassName { source: err })?;
+        schema.insert(String::from("title"), Value::String(name));
+
+        schema.insert(
+            String::from("$schema"),
+            Value::String(String::from("https://json-schema.org/draft/2020-12/schema")),
+        );
+    }
+
+    Ok(schema)
+}
+
+#[derive(Debug, Error)]
+pub enum SchemaError {
+    #[error("codec class' `__schema__` is invalid")]
+    InvalidCachedJsonSchema { source: PythonizeError },
+    #[error("extracting the codec signature failed")]
+    SignatureExtraction {
+        #[from]
+        source: PyErr,
+    },
+    #[error("codec's signature must not contain an `*args` parameter")]
+    ArgsParameterInSignature,
+    #[error("{name} parameter's default value is invalid")]
+    InvalidParameterDefault {
+        name: String,
+        source: PythonizeError,
+    },
+    #[error("codec class's `__doc__` must be a string")]
+    InvalidClassDocs { source: PyErr },
+    #[error("codec class must have a string `__name__`")]
+    InvalidClassName { source: PyErr },
+}

--- a/crates/numcodecs-python/tests/crc32.rs
+++ b/crates/numcodecs-python/tests/crc32.rs
@@ -3,7 +3,10 @@ use numcodecs::{AnyArray, AnyArrayView, AnyCowArray, Codec, DynCodec, DynCodecTy
 use numcodecs_python::{PyCodecAdapter, PyCodecClassMethods, PyCodecMethods, PyCodecRegistry};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
 use serde_json::json;
-use ::{convert_case as _, pythonize as _, schemars as _, serde as _, serde_transcode as _};
+use ::{
+    convert_case as _, pythonize as _, schemars as _, serde as _, serde_transcode as _,
+    thiserror as _,
+};
 
 #[test]
 fn python_api() -> Result<(), PyErr> {

--- a/crates/numcodecs-python/tests/crc32.rs
+++ b/crates/numcodecs-python/tests/crc32.rs
@@ -3,7 +3,7 @@ use numcodecs::{AnyArray, AnyArrayView, AnyCowArray, Codec, DynCodec, DynCodecTy
 use numcodecs_python::{PyCodecAdapter, PyCodecClassMethods, PyCodecMethods, PyCodecRegistry};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
 use serde_json::json;
-use ::{convert_case as _, pythonize as _, serde as _, serde_transcode as _};
+use ::{convert_case as _, pythonize as _, schemars as _, serde as _, serde_transcode as _};
 
 #[test]
 fn python_api() -> Result<(), PyErr> {

--- a/crates/numcodecs-python/tests/export.rs
+++ b/crates/numcodecs-python/tests/export.rs
@@ -5,7 +5,7 @@ use numcodecs::{
 use numcodecs_python::{
     export_codec_class, PyCodecClassAdapter, PyCodecClassMethods, PyCodecMethods, PyCodecRegistry,
 };
-use pyo3::{exceptions::PyTypeError, prelude::*, types::PyDict};
+use pyo3::{exceptions::PyTypeError, intern, prelude::*, types::PyDict};
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use ::{
@@ -93,7 +93,17 @@ A codec that negates its inputs on encoding and decoding.
 
 ## Parameters
 
- - param (optional): An optional integer value."
+This codec does *not* take any parameters."
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                py.import_bound(intern!(py, "inspect"))?
+                    .getattr(intern!(py, "signature"))?
+                    .call1((class.getattr(intern!(py, "__init__"))?,))?
+            ),
+            "(self)",
         );
 
         Ok(())
@@ -104,30 +114,7 @@ A codec that negates its inputs on encoding and decoding.
 #[serde(deny_unknown_fields)]
 /// A codec that negates its inputs on encoding and decoding.
 struct NegateCodec {
-    /// An optional integer value.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    param: Option<i32>,
-    /// The flattened configuration.
-    #[serde(default, flatten)]
-    config: Option<Config>,
-}
-
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "mode")]
-#[serde(deny_unknown_fields)]
-enum Config {
-    /// Mode a.
-    A {
-        /// A boolean value.
-        value: bool,
-        /// A common string value.
-        common: String,
-    },
-    /// Mode b.
-    B {
-        /// A common string value.
-        common: String,
-    },
+    // empty
 }
 
 impl Codec for NegateCodec {

--- a/crates/numcodecs-python/tests/schema.rs
+++ b/crates/numcodecs-python/tests/schema.rs
@@ -1,0 +1,30 @@
+use numcodecs::DynCodecType;
+use numcodecs_python::{PyCodecClass, PyCodecClassAdapter};
+use pyo3::{intern, prelude::*};
+use ::{
+    convert_case as _, ndarray as _, numpy as _, pythonize as _, schemars as _, serde as _,
+    serde_json as _, serde_transcode as _,
+};
+
+#[test]
+fn collect_schemas() -> Result<(), PyErr> {
+    Python::with_gil(|py| {
+        let registry = py
+            .import_bound(intern!(py, "numcodecs"))?
+            .getattr(intern!(py, "registry"))?
+            .getattr(intern!(py, "codec_registry"))?;
+
+        for codec in registry.iter()? {
+            let (codec_id, codec_class): (String, Bound<PyCodecClass>) = codec?.extract()?;
+
+            let codec_ty = PyCodecClassAdapter::from_codec_class(codec_class)?;
+
+            println!(
+                "{codec_id}: {:#}",
+                codec_ty.codec_config_schema().as_value()
+            );
+        }
+
+        panic!("")
+    })
+}

--- a/crates/numcodecs-python/tests/schema.rs
+++ b/crates/numcodecs-python/tests/schema.rs
@@ -14,7 +14,7 @@ fn collect_schemas() -> Result<(), PyErr> {
             .getattr(intern!(py, "registry"))?
             .getattr(intern!(py, "codec_registry"))?;
 
-        for codec in registry.iter()? {
+        for codec in registry.call_method0(intern!(py, "items"))?.iter()? {
             let (codec_id, codec_class): (String, Bound<PyCodecClass>) = codec?.extract()?;
 
             let codec_ty = PyCodecClassAdapter::from_codec_class(codec_class)?;

--- a/crates/numcodecs-python/tests/schema.rs
+++ b/crates/numcodecs-python/tests/schema.rs
@@ -3,7 +3,7 @@ use numcodecs_python::{PyCodecClass, PyCodecClassAdapter};
 use pyo3::{intern, prelude::*};
 use ::{
     convert_case as _, ndarray as _, numpy as _, pythonize as _, schemars as _, serde as _,
-    serde_json as _, serde_transcode as _,
+    serde_json as _, serde_transcode as _, thiserror as _,
 };
 
 #[test]
@@ -25,6 +25,6 @@ fn collect_schemas() -> Result<(), PyErr> {
             );
         }
 
-        panic!("")
+        Ok(())
     })
 }

--- a/crates/numcodecs-wasm-guest/Cargo.toml
+++ b/crates/numcodecs-wasm-guest/Cargo.toml
@@ -19,6 +19,7 @@ wit-bindgen = { workspace = true, features = ["macros", "realloc"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 format_serde_error = { workspace = true, features = ["serde_json"] }
 ndarray = { workspace = true, features = ["std"] }
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }

--- a/crates/numcodecs/Cargo.toml
+++ b/crates/numcodecs/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["numcodecs", "compression", "encoding"]
 
 [dependencies]
 ndarray = { workspace = true }
+schemars = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }

--- a/crates/numcodecs/src/array.rs
+++ b/crates/numcodecs/src/array.rs
@@ -4,6 +4,7 @@ use ndarray::{
     ArrayBase, ArrayD, CowRepr, Data, DataMut, Dimension, IxDyn, OwnedArcRepr, OwnedRepr, RawData,
     RawDataClone, RawDataSubst, ViewRepr,
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -641,7 +642,7 @@ impl<
 }
 
 /// Enum of all dtypes included in [`AnyArrayBase`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("enum" = [
     "u8", "uint8",
     "u16", "uint16",

--- a/crates/numcodecs/src/array.rs
+++ b/crates/numcodecs/src/array.rs
@@ -641,7 +641,19 @@ impl<
 }
 
 /// Enum of all dtypes included in [`AnyArrayBase`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+#[schemars(extend("enum" = [
+    "u8", "uint8",
+    "u16", "uint16",
+    "u32", "uint32",
+    "u64", "uint64",
+    "i8", "int8",
+    "i16", "int16",
+    "i32", "int32",
+    "i64", "int64",
+    "f32", "float32",
+    "f64", "float64"
+]))]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum AnyArrayDType {

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, error::Error, marker::PhantomData};
 
-use schemars::{schema_for, JsonSchema, Schema};
+use schemars::{gen::SchemaSettings, JsonSchema, Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
@@ -150,7 +150,13 @@ impl<T: StaticCodec> DynCodecType for StaticCodecType<T> {
     }
 
     fn codec_config_schema(&self) -> Schema {
-        schema_for!(T::Config<'static>)
+        let mut settings = SchemaSettings::draft2020_12();
+        // TODO: perhaps this could be done as a more generally applicable
+        //       transformation instead
+        settings.inline_subschemas = true;
+        settings
+            .into_generator()
+            .into_root_schema_for::<T::Config<'static>>()
     }
 
     fn codec_from_config<'de, D: Deserializer<'de>>(

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, error::Error, marker::PhantomData};
 
-use schemars::JsonSchema;
+use schemars::{schema_for, JsonSchema, Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
@@ -96,6 +96,9 @@ pub trait DynCodecType: 'static + Send + Sync {
     /// Codec identifier.
     fn codec_id(&self) -> &str;
 
+    /// JSON schema for the codec's configuration.
+    fn codec_config_schema(&self) -> Schema;
+
     /// Instantiate a codec of this type from a serialized `config`uration.
     ///
     /// The `config` must *not* contain an `id` field. If the `config` *may*
@@ -144,6 +147,10 @@ impl<T: StaticCodec> DynCodecType for StaticCodecType<T> {
 
     fn codec_id(&self) -> &str {
         T::CODEC_ID
+    }
+
+    fn codec_config_schema(&self) -> Schema {
+        schema_for!(T::Config<'static>)
     }
 
     fn codec_from_config<'de, D: Deserializer<'de>>(

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -179,7 +179,7 @@ impl<'a, T: StaticCodec> StaticCodecConfig<'a, T> {
     /// Wraps the `config` so that it can be serialized together with its
     /// [`StaticCodec::CODEC_ID`]
     #[must_use]
-    pub fn new(config: T::Config<'a>) -> Self {
+    pub const fn new(config: T::Config<'a>) -> Self {
         Self {
             id: StaticCodecId::of(),
             config,

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -1,5 +1,6 @@
-use std::{error::Error, marker::PhantomData};
+use std::{borrow::Cow, error::Error, marker::PhantomData};
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
@@ -39,6 +40,39 @@ pub trait Codec: 'static + Send + Sync + Clone {
         encoded: AnyArrayView,
         decoded: AnyArrayViewMut,
     ) -> Result<(), Self::Error>;
+}
+
+/// Statically typed compression codec.
+pub trait StaticCodec: Codec {
+    /// Codec identifier.
+    const CODEC_ID: &'static str;
+
+    /// Configuration type, from which the codec can be created infallibly.
+    /// 
+    /// The `config` must *not* contain an `id` field.
+    /// 
+    /// The config *must* be compatible with JSON encoding and have a schema.
+    type Config<'de>: Serialize + Deserialize<'de> + JsonSchema;
+
+    /// Instantiate a codec from its `config`uration.
+    fn from_config<'de>(config: Self::Config<'de>) -> Self;
+
+    /// Get the configuration for this codec.
+    /// 
+    /// The [`StaticCodecConfig`] ensures that the returned config includes an
+    /// `id` field with the codec's [`StaticCodec::CODEC_ID`].
+    fn get_config(&self) -> StaticCodecConfig<Self>;
+}
+
+/// Dynamically typed compression codec.
+///
+/// Every codec that implements [`StaticCodec`] also implements [`DynCodec`].
+pub trait DynCodec: Codec {
+    /// Type object type for this codec.
+    type Type: DynCodecType;
+
+    /// Returns the type object for this codec.
+    fn ty(&self) -> Self::Type;
 
     /// Serializes the configuration parameters for this codec.
     ///
@@ -52,35 +86,6 @@ pub trait Codec: 'static + Send + Sync + Clone {
     ///
     /// Errors if serializing the codec configuration fails.
     fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error>;
-}
-
-/// Statically typed compression codec.
-pub trait StaticCodec: Codec {
-    /// Codec identifier.
-    const CODEC_ID: &'static str;
-
-    /// Instantiate a codec from a serialized `config`uration.
-    ///
-    /// The `config` must *not* contain an `id` field. If the `config` *may*
-    /// contain one, use the [`codec_from_config_with_id`] helper function.
-    ///
-    /// The `config` *must* be compatible with JSON encoding.
-    ///
-    /// # Errors
-    ///
-    /// Errors if constructing the codec fails.
-    fn from_config<'de, D: Deserializer<'de>>(config: D) -> Result<Self, D::Error>;
-}
-
-/// Dynamically typed compression codec.
-///
-/// Every codec that implements [`StaticCodec`] also implements [`DynCodec`].
-pub trait DynCodec: Codec {
-    /// Type object type for this codec.
-    type Type: DynCodecType;
-
-    /// Returns the type object for this codec.
-    fn ty(&self) -> Self::Type;
 }
 
 /// Type object for dynamically typed compression codecs.
@@ -113,6 +118,10 @@ impl<T: StaticCodec> DynCodec for T {
     fn ty(&self) -> Self::Type {
         StaticCodecType::of()
     }
+
+    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        <T as StaticCodec>::get_config(self).serialize(serializer)
+    }
 }
 
 /// Type object for statically typed compression codecs.
@@ -141,7 +150,71 @@ impl<T: StaticCodec> DynCodecType for StaticCodecType<T> {
         &self,
         config: D,
     ) -> Result<Self::Codec, D::Error> {
-        T::from_config(config)
+        let config = T::Config::deserialize(config)?;
+        Ok(T::from_config(config))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct StaticCodecConfig<'a, T: StaticCodec> {
+    #[serde(default)]
+    id: StaticCodecId<T>,
+    #[serde(flatten)]
+    #[serde(borrow)]
+    pub config: T::Config<'a>,
+}
+
+impl<'a, T: StaticCodec> StaticCodecConfig<'a, T> {
+    #[must_use]
+    pub fn new(config: T::Config<'a>) -> Self {
+        Self {
+            id: StaticCodecId::of(),
+            config,
+        }
+    }
+}
+
+impl<'a, T: StaticCodec> From<&T::Config<'a>> for StaticCodecConfig<'a, T> where T::Config<'a>: Clone {
+    fn from(config: &T::Config<'a>) -> Self {
+        Self::new(config.clone())
+    }
+}
+
+struct StaticCodecId<T: StaticCodec>(PhantomData<T>);
+
+impl<T: StaticCodec> StaticCodecId<T> {
+    #[must_use]
+    pub fn of() -> Self {
+        Self(PhantomData::<T>)
+    }
+}
+
+impl<T: StaticCodec> Default for StaticCodecId<T> {
+    fn default() -> Self {
+        Self::of()
+    }
+}
+
+impl<T: StaticCodec> Serialize for StaticCodecId<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        T::CODEC_ID.serialize(serializer)
+    }
+}
+
+impl<'de, T: StaticCodec> Deserialize<'de> for StaticCodecId<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let id = Cow::<str>::deserialize(deserializer)?;
+        let id = &*id;
+
+        if id != T::CODEC_ID {
+            return Err(serde::de::Error::custom(format!(
+                "expected codec id {:?} but found {id:?}",
+                T::CODEC_ID,
+            )));
+        }
+        
+        Ok(Self::of())
     }
 }
 
@@ -160,13 +233,13 @@ pub fn serialize_codec_config_with_id<T: Serialize, C: DynCodec, S: Serializer>(
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     #[derive(Serialize)]
-    struct CodecConfigWithId<'a, T> {
+    struct DynCodecConfigWithId<'a, T> {
         id: &'a str,
         #[serde(flatten)]
         config: &'a T,
     }
 
-    CodecConfigWithId {
+    DynCodecConfigWithId {
         id: codec.ty().codec_id(),
         config,
     }

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, error::Error, marker::PhantomData};
 
-use schemars::{gen::SchemaSettings, JsonSchema, Schema};
+use schemars::{generate::SchemaSettings, JsonSchema, Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 

--- a/crates/numcodecs/src/lib.rs
+++ b/crates/numcodecs/src/lib.rs
@@ -28,7 +28,7 @@ pub use array::{
 };
 pub use codec::{
     codec_from_config_with_id, serialize_codec_config_with_id, Codec, DynCodec, DynCodecType,
-    StaticCodec, StaticCodecType,
+    StaticCodec, StaticCodecType, StaticCodecConfig,
 };
 
 mod sealed {

--- a/crates/numcodecs/src/lib.rs
+++ b/crates/numcodecs/src/lib.rs
@@ -28,7 +28,7 @@ pub use array::{
 };
 pub use codec::{
     codec_from_config_with_id, serialize_codec_config_with_id, Codec, DynCodec, DynCodecType,
-    StaticCodec, StaticCodecType, StaticCodecConfig,
+    StaticCodec, StaticCodecConfig, StaticCodecType,
 };
 
 mod sealed {

--- a/wit/codecs.wit
+++ b/wit/codecs.wit
@@ -1,6 +1,8 @@
 package numcodecs:abc@0.1.0;
 
 interface codec {
+    type json = string;
+    type json-schema = json;
     type usize = u32;
 
     record any-array {
@@ -27,11 +29,13 @@ interface codec {
     }
 
     resource codec {
-        from-config: static func(config: string) -> result<codec, error>;
+        from-config: static func(config: json) -> result<codec, error>;
         encode: func(data: any-array) -> result<any-array, error>;
         decode: func(encoded: any-array) -> result<any-array, error>;
-        get-config: func() -> result<string, error>;
+        get-config: func() -> result<json, error>;
     }
 
     codec-id: func() -> string;
+
+    codec-config-schema: func() -> json-schema;
 }


### PR DESCRIPTION
Codecs now provide the JSON schema for the configuration. This is an API addition in comparison to the Python numcodecs package, but makes sense since the Python package already requires that codec configs must be in JSON format.

Static codecs must implement the `schemars::JsonSchema` trait for their config type, dynamic codec types must be able to return their schema.

For Python interop, exported Rust codecs use the schema to generate simple docs and a simple signature, which includes (simple) parameter names and defaults, but no types. Imported Python codecs generate a simple schema based on their signature and docs. Both conversions check for double-wrapping to roundtrip existing trusted schemas / docs / signatures through the otherwise lossy schema processes.