### PR TITLE
Improve error reporting with pyo3-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ndarray = { version = "0.15", default-features = false } # keep in sync with num
 numpy = { version = "0.21", default-features = false }
 postcard = { version = "1.0", default-features = false }
 pyo3 = { version = "0.21", default-features = false }
-pyo3-error = { git = "https://github.com/juntyr/pyo3-error.git", rev = "9ad403e", version = "0.1", default-features = false }
+pyo3-error = { version = "0.1", default-features = false }
 pythonize = { version = "0.21", default-features = false }
 rand = { version = "0.8", default-features = false }
 schemars = { version = "=1.0.0-alpha.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,11 @@ numcodecs-zstd = { version = "0.1", path = "codecs/zstd", default-features = fal
 convert_case = { version = "0.6", default-features = false }
 format_serde_error = { version = "0.3", default-features = false }
 miniz_oxide = { version = "0.8", default-features = false }
-numpy = { version = "0.21", default-features = false }
 ndarray = { version = "0.15", default-features = false } # keep in sync with numpy
+numpy = { version = "0.21", default-features = false }
 postcard = { version = "1.0", default-features = false }
 pyo3 = { version = "0.21", default-features = false }
+pyo3-error = { git = "https://github.com/juntyr/pyo3-error.git", rev = "535e5c6", version = "0.1", default-features = false }
 pythonize = { version = "0.21", default-features = false }
 rand = { version = "0.8", default-features = false }
 schemars = { version = "=1.0.0-alpha.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ndarray = { version = "0.15", default-features = false } # keep in sync with num
 numpy = { version = "0.21", default-features = false }
 postcard = { version = "1.0", default-features = false }
 pyo3 = { version = "0.21", default-features = false }
-pyo3-error = { git = "https://github.com/juntyr/pyo3-error.git", rev = "535e5c6", version = "0.1", default-features = false }
+pyo3-error = { git = "https://github.com/juntyr/pyo3-error.git", rev = "7002874", version = "0.1", default-features = false }
 pythonize = { version = "0.21", default-features = false }
 rand = { version = "0.8", default-features = false }
 schemars = { version = "=1.0.0-alpha.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ndarray = { version = "0.15", default-features = false } # keep in sync with num
 numpy = { version = "0.21", default-features = false }
 postcard = { version = "1.0", default-features = false }
 pyo3 = { version = "0.21", default-features = false }
-pyo3-error = { git = "https://github.com/juntyr/pyo3-error.git", rev = "7002874", version = "0.1", default-features = false }
+pyo3-error = { git = "https://github.com/juntyr/pyo3-error.git", rev = "9ad403e", version = "0.1", default-features = false }
 pythonize = { version = "0.21", default-features = false }
 rand = { version = "0.8", default-features = false }
 schemars = { version = "=1.0.0-alpha.9", default-features = false }

--- a/crates/numcodecs-python/Cargo.toml
+++ b/crates/numcodecs-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-python"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/crates/numcodecs-python/Cargo.toml
+++ b/crates/numcodecs-python/Cargo.toml
@@ -20,6 +20,7 @@ ndarray = { workspace = true }
 numcodecs = { workspace = true }
 numpy = { workspace = true }
 pyo3 = { workspace = true }
+pyo3-error = { workspace = true }
 pythonize = { workspace = true }
 schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true }

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -121,11 +121,11 @@ trait AnyCodec {
 
 impl<T: DynCodec> AnyCodec for T {
     fn encode(&self, py: Python, data: AnyCowArray) -> Result<AnyArray, PyErr> {
-        <T as Codec>::encode(self, data).map_err(|err| PyErrChain::new(py, err).into())
+        <T as Codec>::encode(self, data).map_err(|err| PyErrChain::pyerr_from_err(py, err))
     }
 
     fn decode(&self, py: Python, encoded: AnyCowArray) -> Result<AnyArray, PyErr> {
-        <T as Codec>::decode(self, encoded).map_err(|err| PyErrChain::new(py, err).into())
+        <T as Codec>::decode(self, encoded).map_err(|err| PyErrChain::pyerr_from_err(py, err))
     }
 
     fn decode_into(
@@ -135,7 +135,7 @@ impl<T: DynCodec> AnyCodec for T {
         decoded: AnyArrayViewMut,
     ) -> Result<(), PyErr> {
         <T as Codec>::decode_into(self, encoded, decoded)
-            .map_err(|err| PyErrChain::new(py, err).into())
+            .map_err(|err| PyErrChain::pyerr_from_err(py, err))
     }
 
     fn get_config<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>, PyErr> {

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -9,12 +9,13 @@ use numpy::{
     PyUntypedArrayMethods,
 };
 use pyo3::{
-    exceptions::{PyRuntimeError, PyTypeError, PyValueError},
+    exceptions::PyTypeError,
     intern,
     prelude::*,
     types::{IntoPyDict, PyDict, PyString, PyType},
     PyTypeInfo,
 };
+use pyo3_error::PyErrChain;
 use pythonize::{pythonize, Depythonizer, Pythonizer};
 
 use crate::{
@@ -102,11 +103,16 @@ impl RustCodecType {
 }
 
 trait AnyCodec {
-    fn encode(&self, data: AnyCowArray) -> Result<AnyArray, PyErr>;
+    fn encode(&self, py: Python, data: AnyCowArray) -> Result<AnyArray, PyErr>;
 
-    fn decode(&self, encoded: AnyCowArray) -> Result<AnyArray, PyErr>;
+    fn decode(&self, py: Python, encoded: AnyCowArray) -> Result<AnyArray, PyErr>;
 
-    fn decode_into(&self, encoded: AnyArrayView, decoded: AnyArrayViewMut) -> Result<(), PyErr>;
+    fn decode_into(
+        &self,
+        py: Python,
+        encoded: AnyArrayView,
+        decoded: AnyArrayViewMut,
+    ) -> Result<(), PyErr>;
 
     fn get_config<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>, PyErr>;
 
@@ -114,17 +120,22 @@ trait AnyCodec {
 }
 
 impl<T: DynCodec> AnyCodec for T {
-    fn encode(&self, data: AnyCowArray) -> Result<AnyArray, PyErr> {
-        <T as Codec>::encode(self, data).map_err(|err| PyRuntimeError::new_err(format!("{err}")))
+    fn encode(&self, py: Python, data: AnyCowArray) -> Result<AnyArray, PyErr> {
+        <T as Codec>::encode(self, data).map_err(|err| PyErrChain::new(py, err).into())
     }
 
-    fn decode(&self, encoded: AnyCowArray) -> Result<AnyArray, PyErr> {
-        <T as Codec>::decode(self, encoded).map_err(|err| PyRuntimeError::new_err(format!("{err}")))
+    fn decode(&self, py: Python, encoded: AnyCowArray) -> Result<AnyArray, PyErr> {
+        <T as Codec>::decode(self, encoded).map_err(|err| PyErrChain::new(py, err).into())
     }
 
-    fn decode_into(&self, encoded: AnyArrayView, decoded: AnyArrayViewMut) -> Result<(), PyErr> {
+    fn decode_into(
+        &self,
+        py: Python,
+        encoded: AnyArrayView,
+        decoded: AnyArrayViewMut,
+    ) -> Result<(), PyErr> {
         <T as Codec>::decode_into(self, encoded, decoded)
-            .map_err(|err| PyRuntimeError::new_err(format!("{err}")))
+            .map_err(|err| PyErrChain::new(py, err).into())
     }
 
     fn get_config<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>, PyErr> {
@@ -198,7 +209,7 @@ impl RustCodec {
         let ty: Bound<RustCodecType> = cls
             .getattr(intern!(py, RustCodec::TYPE_ATTRIBUTE))
             .map_err(|_| {
-                PyValueError::new_err(format!(
+                PyTypeError::new_err(format!(
                     "{cls_module}.{cls_name} is not linked to a Rust codec type"
                 ))
             })?
@@ -307,12 +318,13 @@ impl RustCodec {
         buf: Borrowed<'_, 'py, PyAny>,
         process: impl FnOnce(
             &(dyn 'static + Send + Sync + AnyCodec),
+            Python,
             AnyCowArray,
         ) -> Result<AnyArray, PyErr>,
         class_method: &str,
     ) -> Result<Bound<'py, PyAny>, PyErr> {
         Self::with_pyarraylike_as_cow(py, buf, class_method, |data| {
-            let processed = process(&*self.codec, data)?;
+            let processed = process(&*self.codec, py, data)?;
             Self::any_array_into_pyarray(py, processed, class_method)
         })
     }
@@ -324,6 +336,7 @@ impl RustCodec {
         out: Borrowed<'_, 'py, PyAny>,
         process: impl FnOnce(
             &(dyn 'static + Send + Sync + AnyCodec),
+            Python,
             AnyArrayView,
             AnyArrayViewMut,
         ) -> Result<(), PyErr>,
@@ -331,7 +344,7 @@ impl RustCodec {
     ) -> Result<(), PyErr> {
         Self::with_pyarraylike_as_view(py, buf, class_method, |data| {
             Self::with_pyarraylike_as_view_mut(py, out, class_method, |data_out| {
-                process(&*self.codec, data, data_out)
+                process(&*self.codec, py, data, data_out)
             })
         })
     }

--- a/crates/numcodecs-python/tests/crc32.rs
+++ b/crates/numcodecs-python/tests/crc32.rs
@@ -76,7 +76,7 @@ fn rust_api() -> Result<(), PyErr> {
     let codec = PyCodecAdapter::from_registry_with_config(json!({
         "id": "crc32",
     }))
-    .map_err(|err| Python::with_gil(|py| PyErr::from(PyErrChain::new(py, err))))?;
+    .map_err(|err| Python::with_gil(|py| PyErrChain::pyerr_from_err(py, err)))?;
     assert_eq!(codec.ty().codec_id(), "crc32");
 
     // clone the codec
@@ -86,12 +86,12 @@ fn rust_api() -> Result<(), PyErr> {
     let codec = codec
         .ty()
         .codec_from_config(json!({}))
-        .map_err(|err| Python::with_gil(|py| PyErr::from(PyErrChain::new(py, err))))?;
+        .map_err(|err| Python::with_gil(|py| PyErrChain::pyerr_from_err(py, err)))?;
 
     // check the codec's config
     let config = codec
         .get_config(serde_json::value::Serializer)
-        .map_err(|err| Python::with_gil(|py| PyErr::from(PyErrChain::new(py, err))))?;
+        .map_err(|err| Python::with_gil(|py| PyErrChain::pyerr_from_err(py, err)))?;
     assert_eq!(
         config,
         json!({


### PR DESCRIPTION
- [x] add a helper function to perform the conversion to `PyErr` without allocating the chain
  - [x] rewrite the current `new` by first using this function and then the from `PyErr` impl
- [x] ~~should the conversions in this crate use a custom translator?~~
- [x] merge with a minor version bump to `numcodecs-python` once `pyo3-error` is published