### PR TITLE
Compile ZFP with rounding to reduce error bias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: ["1.76", stable, nightly]
+        rust: ["1.77", stable, nightly]
         lock: ["Cargo.lock", "Cargo.lock.min"]
         include:
-          - rust: "1.76"
+          - rust: "1.77"
             wasm32-wasip1: wasm32-wasi
           - rust: stable
             wasm32-wasip1: wasm32-wasip1
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: ["1.76", stable, nightly]
+        rust: ["1.77", stable, nightly]
         lock: ["Cargo.lock", "Cargo.lock.min"]
         python: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
@@ -175,10 +175,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: ["1.76", stable]
+        rust: ["1.77", stable]
         lock: ["Cargo.lock", "Cargo.lock.min"]
         include:
-          - rust: "1.76"
+          - rust: "1.77"
             wasm32-wasip1: wasm32-wasi
           - rust: stable
             wasm32-wasip1: wasm32-wasip1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ thiserror = { version = "1.0.61", default-features = false }
 twofloat = { version = "0.7", default-features = false }
 wit-bindgen = { version = "0.34", default-features = false }
 wyhash = { version = "0.5", default-features = false }
-zfp-sys = { version = "0.1.15", default-features = false } # v0.2.0 requires MSRV 1.77
+zfp-sys = { version = "0.3.0", default-features = false }
 zstd = { version = "0.13", default-features = false }
 zstd-sys = { version = "2.0.12", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 authors = ["Juniper Tyree <juniper.tyree@helsinki.fi>"]
 repository = "https://github.com/juntyr/numcodecs-rs"
 license = "MPL-2.0"
-rust-version = "1.76"
+rust-version = "1.77"
 
 [workspace.dependencies]
 # workspace-internal numcodecs crates

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs

--- a/codecs/asinh/README.md
+++ b/codecs/asinh/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-asinh

--- a/codecs/asinh/src/lib.rs
+++ b/codecs/asinh/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-asinh

--- a/codecs/bit-round/README.md
+++ b/codecs/bit-round/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-bit-round

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-bit-round

--- a/codecs/fixed-offset-scale/README.md
+++ b/codecs/fixed-offset-scale/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-fixed-offset-scale

--- a/codecs/fixed-offset-scale/src/lib.rs
+++ b/codecs/fixed-offset-scale/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-fixed-offset-scale

--- a/codecs/identity/README.md
+++ b/codecs/identity/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-identity

--- a/codecs/identity/src/lib.rs
+++ b/codecs/identity/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-identity

--- a/codecs/linear-quantize/README.md
+++ b/codecs/linear-quantize/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-linear-quantize

--- a/codecs/linear-quantize/src/lib.rs
+++ b/codecs/linear-quantize/src/lib.rs
@@ -5,7 +5,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-linear-quantize

--- a/codecs/log/README.md
+++ b/codecs/log/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-log

--- a/codecs/log/src/lib.rs
+++ b/codecs/log/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-log

--- a/codecs/random-projection/README.md
+++ b/codecs/random-projection/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-random-projection

--- a/codecs/random-projection/src/lib.rs
+++ b/codecs/random-projection/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-random-projection

--- a/codecs/reinterpret/README.md
+++ b/codecs/reinterpret/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-reinterpret

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-reinterpret

--- a/codecs/round/README.md
+++ b/codecs/round/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-round

--- a/codecs/round/src/lib.rs
+++ b/codecs/round/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-round

--- a/codecs/swizzle-reshape/README.md
+++ b/codecs/swizzle-reshape/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-swizzle-reshape

--- a/codecs/swizzle-reshape/src/lib.rs
+++ b/codecs/swizzle-reshape/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-swizzle-reshape

--- a/codecs/sz3/README.md
+++ b/codecs/sz3/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-sz3

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-sz3

--- a/codecs/uniform-noise/README.md
+++ b/codecs/uniform-noise/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-uniform-noise

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-uniform-noise

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "numcodecs-zfp"
-version = "0.3.0-nightly.rounding"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-rust-version = "1.77"
+rust-version = { workspace = true }
 
 description = "ZFP codec implementation for the numcodecs API"
 readme = "README.md"

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.77"
 
 description = "ZFP codec implementation for the numcodecs API"
 readme = "README.md"
@@ -20,7 +20,7 @@ numcodecs = { workspace = true }
 schemars = { workspace = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
-zfp-sys = { workspace = true, features = ["static"] }
+zfp-sys = { workspace = true, features = ["static", "round-tight-error"] }
 
 [lints]
 workspace = true

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp"
-version = "0.2.1"
+version = "0.3.0-nightly.rounding"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zfp/README.md
+++ b/codecs/zfp/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-zfp

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-zfp

--- a/codecs/zlib/README.md
+++ b/codecs/zlib/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-zlib

--- a/codecs/zlib/src/lib.rs
+++ b/codecs/zlib/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-zlib

--- a/codecs/zstd/README.md
+++ b/codecs/zstd/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-zstd

--- a/codecs/zstd/src/lib.rs
+++ b/codecs/zstd/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-zstd

--- a/crates/numcodecs-python/README.md
+++ b/crates/numcodecs-python/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-python

--- a/crates/numcodecs-python/src/lib.rs
+++ b/crates/numcodecs-python/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-python

--- a/crates/numcodecs-wasm-guest/README.md
+++ b/crates/numcodecs-wasm-guest/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs-wasm-guest

--- a/crates/numcodecs-wasm-guest/src/lib.rs
+++ b/crates/numcodecs-wasm-guest/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs-wasm-guest

--- a/crates/numcodecs/README.md
+++ b/crates/numcodecs/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+[MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 [repo]: https://github.com/juntyr/numcodecs-rs
 
 [Latest Version]: https://img.shields.io/crates/v/numcodecs

--- a/crates/numcodecs/src/lib.rs
+++ b/crates/numcodecs/src/lib.rs
@@ -3,7 +3,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/numcodecs-rs/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/numcodecs-rs/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.76.0-blue
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.77.0-blue
 //! [repo]: https://github.com/juntyr/numcodecs-rs
 //!
 //! [Latest Version]: https://img.shields.io/crates/v/numcodecs


### PR DESCRIPTION
Compile ZFP with [`ZFP_ROUNDING_MODE`](https://zfp.readthedocs.io/en/release1.0.1/installation.html#c.ZFP_ROUNDING_MODE) and [`ZFP_WITH_TIGHT_ERROR`](https://zfp.readthedocs.io/en/release1.0.1/installation.html#c.ZFP_WITH_TIGHT_ERROR)

This drops compatibility with arrays that were compressed using the default ZFP configuration. Given the large positive impact of rounding, this breakage is acceptable.

- [x] should we add a required (or even default) option for the rounding mode that can only be set to on but ensures that old codec configs cannot be loaded with this breaking change?
  - no, we haven't done that for other breaking changes yet either and it's not v1 yet