### PR TITLE
Add numcodecs entry point

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ rust-version = "1.82"
 
 [workspace.dependencies]
 # workspace-internal numcodecs crates
-numcodecs = { version = "0.2", path = "crates/numcodecs", default-features = false }
-numcodecs-python = { version = "0.5", path = "crates/numcodecs-python", default-features = false }
+numcodecs = { version = "0.2.1", path = "crates/numcodecs", default-features = false }
+numcodecs-python = { version = "0.6", path = "crates/numcodecs-python", default-features = false }
 numcodecs-wasm-builder = { version = "0.1", path = "crates/numcodecs-wasm-builder", default-features = false }
 numcodecs-wasm-logging = { version = "0.1", path = "crates/numcodecs-wasm-logging", default-features = false }
 numcodecs-wasm-guest = { version = "0.2", path = "crates/numcodecs-wasm-guest", default-features = false }
@@ -53,26 +53,26 @@ numcodecs-wasm-host-reproducible = { version = "0.1", path = "crates/numcodecs-w
 numcodecs-wasm = { version = "0.1", path = "py/numcodecs-wasm", default-features = false }
 
 # workspace-internal codecs crates
-numcodecs-asinh = { version = "0.2", path = "codecs/asinh", default-features = false }
-numcodecs-bit-round = { version = "0.2", path = "codecs/bit-round", default-features = false }
-numcodecs-fixed-offset-scale = { version = "0.2", path = "codecs/fixed-offset-scale", default-features = false }
-numcodecs-fourier-network = { version = "0.1", path = "codecs/fourier-network", default-features = false }
-numcodecs-identity = { version = "0.2", path = "codecs/identity", default-features = false }
-numcodecs-jpeg2000 = { version = "0.1", path = "codecs/jpeg2000", default-features = false }
-numcodecs-linear-quantize = { version = "0.3", path = "codecs/linear-quantize", default-features = false }
-numcodecs-log = { version = "0.3", path = "codecs/log", default-features = false }
-numcodecs-pco = { version = "0.1", path = "codecs/pco", default-features = false }
-numcodecs-random-projection = { version = "0.2", path = "codecs/random-projection", default-features = false }
-numcodecs-reinterpret = { version = "0.2", path = "codecs/reinterpret", default-features = false }
-numcodecs-round = { version = "0.2", path = "codecs/round", default-features = false }
-numcodecs-swizzle-reshape = { version = "0.2", path = "codecs/swizzle-reshape", default-features = false }
-numcodecs-sz3 = { version = "0.5", path = "codecs/sz3", default-features = false }
-numcodecs-tthresh = { version = "0.1", path = "codecs/tthresh", default-features = false }
-numcodecs-uniform-noise = { version = "0.2", path = "codecs/uniform-noise", default-features = false }
-numcodecs-zfp = { version = "0.4", path = "codecs/zfp", default-features = false }
-numcodecs-zfp-classic = { version = "0.2", path = "codecs/zfp-classic", default-features = false }
-numcodecs-zlib = { version = "0.2", path = "codecs/zlib", default-features = false }
-numcodecs-zstd = { version = "0.2", path = "codecs/zstd", default-features = false }
+numcodecs-asinh = { version = "0.3", path = "codecs/asinh", default-features = false }
+numcodecs-bit-round = { version = "0.3", path = "codecs/bit-round", default-features = false }
+numcodecs-fixed-offset-scale = { version = "0.3", path = "codecs/fixed-offset-scale", default-features = false }
+numcodecs-fourier-network = { version = "0.2", path = "codecs/fourier-network", default-features = false }
+numcodecs-identity = { version = "0.3", path = "codecs/identity", default-features = false }
+numcodecs-jpeg2000 = { version = "0.2", path = "codecs/jpeg2000", default-features = false }
+numcodecs-linear-quantize = { version = "0.4", path = "codecs/linear-quantize", default-features = false }
+numcodecs-log = { version = "0.4", path = "codecs/log", default-features = false }
+numcodecs-pco = { version = "0.2", path = "codecs/pco", default-features = false }
+numcodecs-random-projection = { version = "0.3", path = "codecs/random-projection", default-features = false }
+numcodecs-reinterpret = { version = "0.3", path = "codecs/reinterpret", default-features = false }
+numcodecs-round = { version = "0.3", path = "codecs/round", default-features = false }
+numcodecs-swizzle-reshape = { version = "0.3", path = "codecs/swizzle-reshape", default-features = false }
+numcodecs-sz3 = { version = "0.6", path = "codecs/sz3", default-features = false }
+numcodecs-tthresh = { version = "0.2", path = "codecs/tthresh", default-features = false }
+numcodecs-uniform-noise = { version = "0.3", path = "codecs/uniform-noise", default-features = false }
+numcodecs-zfp = { version = "0.5", path = "codecs/zfp", default-features = false }
+numcodecs-zfp-classic = { version = "0.3", path = "codecs/zfp-classic", default-features = false }
+numcodecs-zlib = { version = "0.3", path = "codecs/zlib", default-features = false }
+numcodecs-zstd = { version = "0.3", path = "codecs/zstd", default-features = false }
 
 # crates.io third-party dependencies
 anyhow = { version = "1.0.93", default-features = false }

--- a/codecs/asinh/Cargo.toml
+++ b/codecs/asinh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-asinh"
-version = "0.2.1"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/asinh/src/lib.rs
+++ b/codecs/asinh/src/lib.rs
@@ -48,8 +48,8 @@ pub struct AsinhCodec {
     /// nearly linear
     pub linear_width: f64,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for AsinhCodec {

--- a/codecs/asinh/src/lib.rs
+++ b/codecs/asinh/src/lib.rs
@@ -21,7 +21,7 @@ use ndarray::{Array, ArrayBase, ArrayView, ArrayViewMut, Data, Dimension, Zip};
 use num_traits::{Float, Signed};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -46,7 +46,10 @@ use thiserror::Error;
 pub struct AsinhCodec {
     /// The width of the close-to-zero input value range where the transform is
     /// nearly linear
-    linear_width: f64,
+    pub linear_width: f64,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for AsinhCodec {

--- a/codecs/asinh/src/lib.rs
+++ b/codecs/asinh/src/lib.rs
@@ -99,7 +99,7 @@ impl Codec for AsinhCodec {
 }
 
 impl StaticCodec for AsinhCodec {
-    const CODEC_ID: &'static str = "asinh";
+    const CODEC_ID: &'static str = "asinh.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/asinh/src/lib.rs
+++ b/codecs/asinh/src/lib.rs
@@ -47,7 +47,7 @@ pub struct AsinhCodec {
     /// The width of the close-to-zero input value range where the transform is
     /// nearly linear
     pub linear_width: f64,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/bit-round/Cargo.toml
+++ b/codecs/bit-round/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-bit-round"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -46,8 +46,8 @@ pub struct BitRoundCodec {
     /// transformation is performed.
     pub keepbits: u8,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for BitRoundCodec {

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -80,7 +80,7 @@ impl Codec for BitRoundCodec {
 }
 
 impl StaticCodec for BitRoundCodec {
-    const CODEC_ID: &'static str = "bit-round";
+    const CODEC_ID: &'static str = "bit-round.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -20,7 +20,7 @@
 use ndarray::{Array, ArrayBase, Data, Dimension};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -45,6 +45,9 @@ pub struct BitRoundCodec {
     /// If keepbits is equal to the bitlength of the dtype's mantissa, no
     /// transformation is performed.
     pub keepbits: u8,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for BitRoundCodec {

--- a/codecs/bit-round/src/lib.rs
+++ b/codecs/bit-round/src/lib.rs
@@ -45,7 +45,7 @@ pub struct BitRoundCodec {
     /// If keepbits is equal to the bitlength of the dtype's mantissa, no
     /// transformation is performed.
     pub keepbits: u8,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/fixed-offset-scale/Cargo.toml
+++ b/codecs/fixed-offset-scale/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-fixed-offset-scale"
-version = "0.2.1"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/fixed-offset-scale/src/lib.rs
+++ b/codecs/fixed-offset-scale/src/lib.rs
@@ -44,8 +44,8 @@ pub struct FixedOffsetScaleCodec {
     /// The scale of the data.
     pub scale: f64,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for FixedOffsetScaleCodec {

--- a/codecs/fixed-offset-scale/src/lib.rs
+++ b/codecs/fixed-offset-scale/src/lib.rs
@@ -43,7 +43,7 @@ pub struct FixedOffsetScaleCodec {
     pub offset: f64,
     /// The scale of the data.
     pub scale: f64,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/fixed-offset-scale/src/lib.rs
+++ b/codecs/fixed-offset-scale/src/lib.rs
@@ -109,7 +109,7 @@ impl Codec for FixedOffsetScaleCodec {
 }
 
 impl StaticCodec for FixedOffsetScaleCodec {
-    const CODEC_ID: &'static str = "fixed-offset-scale";
+    const CODEC_ID: &'static str = "fixed-offset-scale.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/fixed-offset-scale/src/lib.rs
+++ b/codecs/fixed-offset-scale/src/lib.rs
@@ -21,7 +21,7 @@ use ndarray::{Array, ArrayBase, ArrayView, ArrayViewMut, Data, Dimension};
 use num_traits::Float;
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -43,6 +43,9 @@ pub struct FixedOffsetScaleCodec {
     pub offset: f64,
     /// The scale of the data.
     pub scale: f64,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for FixedOffsetScaleCodec {

--- a/codecs/fourier-network/Cargo.toml
+++ b/codecs/fourier-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-fourier-network"
-version = "0.1.1"
+version = "0.2.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/fourier-network/src/lib.rs
+++ b/codecs/fourier-network/src/lib.rs
@@ -89,8 +89,8 @@ pub struct FourierNetworkCodec {
     /// The seed for the random number generator used during encoding
     pub seed: u64,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<0, 1, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<0, 1, 0>,
 }
 
 // using this wrapper function makes an Option<T> required

--- a/codecs/fourier-network/src/lib.rs
+++ b/codecs/fourier-network/src/lib.rs
@@ -176,7 +176,7 @@ impl Codec for FourierNetworkCodec {
 }
 
 impl StaticCodec for FourierNetworkCodec {
-    const CODEC_ID: &'static str = "fourier-network";
+    const CODEC_ID: &'static str = "fourier-network.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/fourier-network/src/lib.rs
+++ b/codecs/fourier-network/src/lib.rs
@@ -88,7 +88,7 @@ pub struct FourierNetworkCodec {
     pub mini_batch_size: Option<NonZeroUsize>,
     /// The seed for the random number generator used during encoding
     pub seed: u64,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<0, 1, 0>,
 }

--- a/codecs/fourier-network/src/lib.rs
+++ b/codecs/fourier-network/src/lib.rs
@@ -40,7 +40,7 @@ use ndarray::{Array, ArrayBase, ArrayView, ArrayViewMut, Data, Dimension, Ix1, O
 use num_traits::{ConstOne, ConstZero, Float as FloatTrait, FromPrimitive};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -88,6 +88,9 @@ pub struct FourierNetworkCodec {
     pub mini_batch_size: Option<NonZeroUsize>,
     /// The seed for the random number generator used during encoding
     pub seed: u64,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<0, 1, 0>,
 }
 
 // using this wrapper function makes an Option<T> required

--- a/codecs/fourier-network/src/modules.rs
+++ b/codecs/fourier-network/src/modules.rs
@@ -99,4 +99,5 @@ pub struct ModelExtra<B: Backend> {
     pub b_t: Param<Tensor<B, 2, Float>>,
     pub mean: Param<Tensor<B, 1, Float>>,
     pub stdv: Param<Tensor<B, 1, Float>>,
+    // FIXME: somehow encode the codec format's version as well
 }

--- a/codecs/fourier-network/src/modules.rs
+++ b/codecs/fourier-network/src/modules.rs
@@ -5,6 +5,7 @@ use burn::{
     module::{Module, Param},
     nn::{BatchNorm, BatchNormConfig, Gelu, Linear, LinearConfig},
     prelude::Backend,
+    record::{PrecisionSettings, Record},
     tensor::{Float, Tensor},
 };
 
@@ -93,11 +94,44 @@ impl ModelConfig {
     }
 }
 
-#[derive(Debug, Module)]
 pub struct ModelExtra<B: Backend> {
-    pub model: Model<B>,
+    pub model: <Model<B> as Module<B>>::Record,
     pub b_t: Param<Tensor<B, 2, Float>>,
     pub mean: Param<Tensor<B, 1, Float>>,
     pub stdv: Param<Tensor<B, 1, Float>>,
-    // FIXME: somehow encode the codec format's version as well
+    pub version: crate::FourierNetworkCodecVersion,
+}
+
+impl<B: Backend> Record<B> for ModelExtra<B> {
+    type Item<S: PrecisionSettings> = ModelExtraItem<B, S>;
+
+    fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
+        ModelExtraItem {
+            model: self.model.into_item(),
+            b_t: self.b_t.into_item(),
+            mean: self.mean.into_item(),
+            stdv: self.stdv.into_item(),
+            version: self.version,
+        }
+    }
+
+    fn from_item<S: PrecisionSettings>(item: Self::Item<S>, device: &B::Device) -> Self {
+        Self {
+            model: Record::<B>::from_item::<S>(item.model, device),
+            b_t: Record::<B>::from_item::<S>(item.b_t, device),
+            mean: Record::<B>::from_item::<S>(item.mean, device),
+            stdv: Record::<B>::from_item::<S>(item.stdv, device),
+            version: item.version,
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
+pub struct ModelExtraItem<B: Backend, S: PrecisionSettings> {
+    model: <<Model<B> as Module<B>>::Record as Record<B>>::Item<S>,
+    b_t: <Param<Tensor<B, 2, Float>> as Record<B>>::Item<S>,
+    mean: <Param<Tensor<B, 1, Float>> as Record<B>>::Item<S>,
+    stdv: <Param<Tensor<B, 1, Float>> as Record<B>>::Item<S>,
+    version: crate::FourierNetworkCodecVersion,
 }

--- a/codecs/fourier-network/tests/schema.json
+++ b/codecs/fourier-network/tests/schema.json
@@ -48,7 +48,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/fourier-network/tests/schema.json
+++ b/codecs/fourier-network/tests/schema.json
@@ -44,6 +44,12 @@
       "format": "uint64",
       "minimum": 0,
       "description": "The seed for the random number generator used during encoding"
+    },
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
     }
   },
   "required": [

--- a/codecs/identity/Cargo.toml
+++ b/codecs/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-identity"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/identity/src/lib.rs
+++ b/codecs/identity/src/lib.rs
@@ -19,7 +19,7 @@
 
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, StaticCodec,
-    StaticCodecConfig,
+    StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,9 @@ use thiserror::Error;
 /// Identity codec which applies the identity function, i.e. passes through the
 /// input unchanged during encoding and decoding.
 pub struct IdentityCodec {
-    // empty
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for IdentityCodec {

--- a/codecs/identity/src/lib.rs
+++ b/codecs/identity/src/lib.rs
@@ -54,7 +54,7 @@ impl Codec for IdentityCodec {
 }
 
 impl StaticCodec for IdentityCodec {
-    const CODEC_ID: &'static str = "identity";
+    const CODEC_ID: &'static str = "identity.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/identity/src/lib.rs
+++ b/codecs/identity/src/lib.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 /// Identity codec which applies the identity function, i.e. passes through the
 /// input unchanged during encoding and decoding.
 pub struct IdentityCodec {
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/identity/src/lib.rs
+++ b/codecs/identity/src/lib.rs
@@ -31,8 +31,8 @@ use thiserror::Error;
 /// input unchanged during encoding and decoding.
 pub struct IdentityCodec {
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for IdentityCodec {

--- a/codecs/jpeg2000/Cargo.toml
+++ b/codecs/jpeg2000/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-jpeg2000"
-version = "0.1.1"
+version = "0.2.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/jpeg2000/src/lib.rs
+++ b/codecs/jpeg2000/src/lib.rs
@@ -134,7 +134,7 @@ impl Codec for Jpeg2000Codec {
 }
 
 impl StaticCodec for Jpeg2000Codec {
-    const CODEC_ID: &'static str = "jpeg2000";
+    const CODEC_ID: &'static str = "jpeg2000.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/jpeg2000/src/lib.rs
+++ b/codecs/jpeg2000/src/lib.rs
@@ -53,8 +53,8 @@ pub struct Jpeg2000Codec {
     #[serde(flatten)]
     pub mode: Jpeg2000CompressionMode,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: Jpeg2000CodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: Jpeg2000CodecVersion,
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]

--- a/codecs/jpeg2000/src/lib.rs
+++ b/codecs/jpeg2000/src/lib.rs
@@ -29,13 +29,15 @@ use ndarray::{Array, Array1, ArrayBase, Axis, Data, Dimension, IxDyn, ShapeError
 use num_traits::identities::Zero;
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 mod ffi;
+
+type Jpeg2000CodecVersion = StaticCodecVersion<0, 1, 0>;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 // serde cannot deny unknown fields because of the flatten
@@ -50,6 +52,9 @@ pub struct Jpeg2000Codec {
     /// JPEG 2000 compression mode
     #[serde(flatten)]
     pub mode: Jpeg2000CompressionMode,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: Jpeg2000CodecVersion,
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
@@ -255,6 +260,7 @@ pub fn compress<T: Jpeg2000Element, S: Data<Elem = T>, D: Dimension>(
         &CompressionHeader {
             dtype: T::DTYPE,
             shape: Cow::Borrowed(data.shape()),
+            version: StaticCodecVersion,
         },
         Vec::new(),
     )
@@ -443,6 +449,7 @@ struct CompressionHeader<'a> {
     dtype: Jpeg2000DType,
     #[serde(borrow)]
     shape: Cow<'a, [usize]>,
+    version: Jpeg2000CodecVersion,
 }
 
 /// Dtypes that JPEG 2000 can compress and decompress

--- a/codecs/jpeg2000/src/lib.rs
+++ b/codecs/jpeg2000/src/lib.rs
@@ -52,7 +52,7 @@ pub struct Jpeg2000Codec {
     /// JPEG 2000 compression mode
     #[serde(flatten)]
     pub mode: Jpeg2000CompressionMode,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: Jpeg2000CodecVersion,
 }

--- a/codecs/jpeg2000/tests/schema.json
+++ b/codecs/jpeg2000/tests/schema.json
@@ -59,7 +59,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/jpeg2000/tests/schema.json
+++ b/codecs/jpeg2000/tests/schema.json
@@ -55,6 +55,14 @@
     }
   ],
   "description": "Codec providing compression using JPEG 2000.\n\n Arrays that are higher-dimensional than 2D are encoded by compressing each\n 2D slice with JPEG 2000 independently. Specifically, the array's shape is\n interpreted as `[.., height, width]`. If you want to compress 2D slices\n along two different axes, you can swizzle the array axes beforehand.",
+  "properties": {
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
+    }
+  },
   "title": "Jpeg2000Codec",
   "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/codecs/linear-quantize/Cargo.toml
+++ b/codecs/linear-quantize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-linear-quantize"
-version = "0.3.1"
+version = "0.4.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/linear-quantize/src/lib.rs
+++ b/codecs/linear-quantize/src/lib.rs
@@ -393,7 +393,7 @@ impl Codec for LinearQuantizeCodec {
 }
 
 impl StaticCodec for LinearQuantizeCodec {
-    const CODEC_ID: &'static str = "linear-quantize";
+    const CODEC_ID: &'static str = "linear-quantize.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/linear-quantize/src/lib.rs
+++ b/codecs/linear-quantize/src/lib.rs
@@ -47,8 +47,8 @@ pub struct LinearQuantizeCodec {
     /// Binary precision of the encoded data where `$bits = \log_{2}(bins)$`
     pub bits: LinearQuantizeBins,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: LinearQuantizeCodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: LinearQuantizeCodecVersion,
 }
 
 /// Data types which the [`LinearQuantizeCodec`] can quantize
@@ -679,7 +679,7 @@ mod tests {
                 dtype: LinearQuantizeDType::F32,
                 #[expect(unsafe_code)]
                 bits: unsafe { std::mem::transmute::<u8, LinearQuantizeBins>(bits) },
-                _version: StaticCodecVersion,
+                version: StaticCodecVersion,
             };
 
             let mut data: Vec<f32> = (0..(u16::MAX >> (16 - bits)))
@@ -713,7 +713,7 @@ mod tests {
                 dtype: LinearQuantizeDType::F32,
                 #[expect(unsafe_code)]
                 bits: unsafe { std::mem::transmute::<u8, LinearQuantizeBins>(bits) },
-                _version: StaticCodecVersion,
+                version: StaticCodecVersion,
             };
 
             #[expect(clippy::cast_precision_loss)]
@@ -749,7 +749,7 @@ mod tests {
                 dtype: LinearQuantizeDType::F64,
                 #[expect(unsafe_code)]
                 bits: unsafe { std::mem::transmute::<u8, LinearQuantizeBins>(bits) },
-                _version: StaticCodecVersion,
+                version: StaticCodecVersion,
             };
 
             let mut data: Vec<f64> = (0..(u32::MAX >> (32 - bits)))
@@ -783,7 +783,7 @@ mod tests {
                 dtype: LinearQuantizeDType::F64,
                 #[expect(unsafe_code)]
                 bits: unsafe { std::mem::transmute::<u8, LinearQuantizeBins>(bits) },
-                _version: StaticCodecVersion,
+                version: StaticCodecVersion,
             };
 
             #[expect(clippy::cast_precision_loss)]
@@ -821,7 +821,7 @@ mod tests {
                 dtype: LinearQuantizeDType::F64,
                 #[expect(unsafe_code)]
                 bits: unsafe { std::mem::transmute::<u8, LinearQuantizeBins>(bits) },
-                _version: StaticCodecVersion,
+                version: StaticCodecVersion,
             };
 
             let encoded = codec.encode(AnyCowArray::F64(CowArray::from(&data).into_dyn()))?;

--- a/codecs/linear-quantize/src/lib.rs
+++ b/codecs/linear-quantize/src/lib.rs
@@ -46,7 +46,7 @@ pub struct LinearQuantizeCodec {
     pub dtype: LinearQuantizeDType,
     /// Binary precision of the encoded data where `$bits = \log_{2}(bins)$`
     pub bits: LinearQuantizeBins,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: LinearQuantizeCodecVersion,
 }

--- a/codecs/log/Cargo.toml
+++ b/codecs/log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-log"
-version = "0.3.1"
+version = "0.4.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/log/src/lib.rs
+++ b/codecs/log/src/lib.rs
@@ -35,8 +35,8 @@ use thiserror::Error;
 /// The codec only supports finite positive floating point numbers.
 pub struct LogCodec {
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for LogCodec {

--- a/codecs/log/src/lib.rs
+++ b/codecs/log/src/lib.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 ///
 /// The codec only supports finite positive floating point numbers.
 pub struct LogCodec {
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/log/src/lib.rs
+++ b/codecs/log/src/lib.rs
@@ -82,7 +82,7 @@ impl Codec for LogCodec {
 }
 
 impl StaticCodec for LogCodec {
-    const CODEC_ID: &'static str = "log";
+    const CODEC_ID: &'static str = "log.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/log/src/lib.rs
+++ b/codecs/log/src/lib.rs
@@ -21,7 +21,7 @@ use ndarray::{Array, ArrayBase, ArrayView, ArrayViewMut, Data, Dimension, Zip};
 use num_traits::{Float, Signed};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,9 @@ use thiserror::Error;
 ///
 /// The codec only supports finite positive floating point numbers.
 pub struct LogCodec {
-    // empty
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for LogCodec {

--- a/codecs/pco/Cargo.toml
+++ b/codecs/pco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-pco"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/pco/src/lib.rs
+++ b/codecs/pco/src/lib.rs
@@ -52,7 +52,7 @@ pub struct Pcodec {
     /// Specifies how the chunk should be split into pages
     #[serde(flatten)]
     pub paging: PcoPagingSpec,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: PcodecVersion,
 }

--- a/codecs/pco/src/lib.rs
+++ b/codecs/pco/src/lib.rs
@@ -335,7 +335,7 @@ impl Codec for Pcodec {
 }
 
 impl StaticCodec for Pcodec {
-    const CODEC_ID: &'static str = "pco";
+    const CODEC_ID: &'static str = "pco.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/pco/src/lib.rs
+++ b/codecs/pco/src/lib.rs
@@ -53,8 +53,8 @@ pub struct Pcodec {
     #[serde(flatten)]
     pub paging: PcoPagingSpec,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: PcodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: PcodecVersion,
 }
 
 #[derive(
@@ -592,7 +592,7 @@ pub fn decompress(encoded: &[u8]) -> Result<AnyArray, PcodecError> {
 /// Errors with
 /// - [`PcodecError::HeaderDecodeFailed`] if decoding the header failed
 /// - [`PcodecError::MismatchedDecodeIntoArray`] if the decoded array has the
-///    wrong dtype or shape
+///   wrong dtype or shape
 /// - [`PcodecError::PcoDecodeFailed`] if decoding failed with an opaque error
 /// - [`PcodecError::DecodeInvalidShapeHeader`] if the array shape header does
 ///   not fit the decoded data

--- a/codecs/pco/tests/schema.json
+++ b/codecs/pco/tests/schema.json
@@ -22,6 +22,12 @@
         12
       ],
       "description": "Compression level, ranging from 0 (weak) over 8 (very good) to 12\n (expensive)"
+    },
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
     }
   },
   "unevaluatedProperties": false,

--- a/codecs/pco/tests/schema.json
+++ b/codecs/pco/tests/schema.json
@@ -26,7 +26,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/random-projection/Cargo.toml
+++ b/codecs/random-projection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-random-projection"
-version = "0.2.1"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/random-projection/src/lib.rs
+++ b/codecs/random-projection/src/lib.rs
@@ -183,7 +183,7 @@ impl Codec for RandomProjectionCodec {
 }
 
 impl StaticCodec for RandomProjectionCodec {
-    const CODEC_ID: &'static str = "random-projection";
+    const CODEC_ID: &'static str = "random-projection.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/random-projection/src/lib.rs
+++ b/codecs/random-projection/src/lib.rs
@@ -58,7 +58,7 @@ pub struct RandomProjectionCodec {
     /// Projection kind that is used to generate the random projection matrix
     #[serde(flatten)]
     pub projection: RandomProjectionKind,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<0, 1, 0>,
 }

--- a/codecs/random-projection/src/lib.rs
+++ b/codecs/random-projection/src/lib.rs
@@ -57,7 +57,8 @@ pub struct RandomProjectionCodec {
     pub reduction: RandomProjectionReduction,
     /// Projection kind that is used to generate the random projection matrix
     #[serde(flatten)]
-    pub projection: RandomProjectionKind,/// The codec's version. Do not provide this parameter explicitly.
+    pub projection: RandomProjectionKind,
+    /// The codec's version. Do not provide this parameter explicitly.
     #[serde(default)]
     pub _version: StaticCodecVersion<0, 1, 0>,
 }

--- a/codecs/random-projection/src/lib.rs
+++ b/codecs/random-projection/src/lib.rs
@@ -23,7 +23,7 @@ use ndarray::{s, Array, ArrayBase, ArrayViewMut, Data, Dimension, Ix2, ShapeErro
 use num_traits::{ConstOne, ConstZero, Float, FloatConst};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -57,7 +57,9 @@ pub struct RandomProjectionCodec {
     pub reduction: RandomProjectionReduction,
     /// Projection kind that is used to generate the random projection matrix
     #[serde(flatten)]
-    pub projection: RandomProjectionKind,
+    pub projection: RandomProjectionKind,/// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<0, 1, 0>,
 }
 
 /// Method with which the reduced dimensionality `$K$` is selected

--- a/codecs/random-projection/src/lib.rs
+++ b/codecs/random-projection/src/lib.rs
@@ -59,8 +59,8 @@ pub struct RandomProjectionCodec {
     #[serde(flatten)]
     pub projection: RandomProjectionKind,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<0, 1, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<0, 1, 0>,
 }
 
 /// Method with which the reduced dimensionality `$K$` is selected

--- a/codecs/random-projection/tests/schema.json
+++ b/codecs/random-projection/tests/schema.json
@@ -6,6 +6,12 @@
       "format": "uint64",
       "minimum": 0,
       "description": "Seed for generating the random projection matrix"
+    },
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
     }
   },
   "required": [

--- a/codecs/random-projection/tests/schema.json
+++ b/codecs/random-projection/tests/schema.json
@@ -10,7 +10,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/reinterpret/Cargo.toml
+++ b/codecs/reinterpret/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-reinterpret"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -20,7 +20,7 @@
 use ndarray::{Array, ArrayBase, ArrayView, Data, DataMut, Dimension, ViewRepr};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    ArrayDType, Codec, StaticCodec, StaticCodecConfig,
+    ArrayDType, Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -39,6 +39,9 @@ pub struct ReinterpretCodec {
     encode_dtype: AnyArrayDType,
     /// Dtype of the decoded data
     decode_dtype: AnyArrayDType,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl ReinterpretCodec {
@@ -75,6 +78,7 @@ impl ReinterpretCodec {
         Ok(Self {
             encode_dtype,
             decode_dtype,
+            _version: StaticCodecVersion,
         })
     }
 
@@ -84,6 +88,7 @@ impl ReinterpretCodec {
         Self {
             encode_dtype: dtype,
             decode_dtype: dtype,
+            _version: StaticCodecVersion,
         }
     }
 
@@ -94,6 +99,7 @@ impl ReinterpretCodec {
         Self {
             encode_dtype: AnyArrayDType::U8,
             decode_dtype: dtype,
+            _version: StaticCodecVersion,
         }
     }
 
@@ -104,6 +110,7 @@ impl ReinterpretCodec {
         Self {
             encode_dtype: dtype.to_binary(),
             decode_dtype: dtype,
+            _version: StaticCodecVersion,
         }
     }
 }

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -39,7 +39,7 @@ pub struct ReinterpretCodec {
     encode_dtype: AnyArrayDType,
     /// Dtype of the decoded data
     decode_dtype: AnyArrayDType,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default)]
     _version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -298,7 +298,7 @@ impl Codec for ReinterpretCodec {
 }
 
 impl StaticCodec for ReinterpretCodec {
-    const CODEC_ID: &'static str = "reinterpret";
+    const CODEC_ID: &'static str = "reinterpret.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/reinterpret/src/lib.rs
+++ b/codecs/reinterpret/src/lib.rs
@@ -73,7 +73,7 @@ impl ReinterpretCodec {
                     encode_dtype,
                 })
             }
-        };
+        }
 
         Ok(Self {
             encode_dtype,

--- a/codecs/round/Cargo.toml
+++ b/codecs/round/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-round"
-version = "0.2.2"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/round/src/lib.rs
+++ b/codecs/round/src/lib.rs
@@ -39,8 +39,8 @@ pub struct RoundCodec {
     /// Precision of the rounding operation
     pub precision: Positive<f64>,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for RoundCodec {

--- a/codecs/round/src/lib.rs
+++ b/codecs/round/src/lib.rs
@@ -23,7 +23,7 @@ use ndarray::{Array, ArrayBase, Data, Dimension};
 use num_traits::Float;
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -38,6 +38,9 @@ use thiserror::Error;
 pub struct RoundCodec {
     /// Precision of the rounding operation
     pub precision: Positive<f64>,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for RoundCodec {

--- a/codecs/round/src/lib.rs
+++ b/codecs/round/src/lib.rs
@@ -77,7 +77,7 @@ impl Codec for RoundCodec {
 }
 
 impl StaticCodec for RoundCodec {
-    const CODEC_ID: &'static str = "round";
+    const CODEC_ID: &'static str = "round.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/round/src/lib.rs
+++ b/codecs/round/src/lib.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 pub struct RoundCodec {
     /// Precision of the rounding operation
     pub precision: Positive<f64>,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/swizzle-reshape/Cargo.toml
+++ b/codecs/swizzle-reshape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-swizzle-reshape"
-version = "0.2.1"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/swizzle-reshape/src/lib.rs
+++ b/codecs/swizzle-reshape/src/lib.rs
@@ -192,7 +192,7 @@ impl Codec for SwizzleReshapeCodec {
 }
 
 impl StaticCodec for SwizzleReshapeCodec {
-    const CODEC_ID: &'static str = "swizzle-reshape";
+    const CODEC_ID: &'static str = "swizzle-reshape.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/swizzle-reshape/src/lib.rs
+++ b/codecs/swizzle-reshape/src/lib.rs
@@ -63,7 +63,7 @@ pub struct SwizzleReshapeCodec {
     /// - `[[0], [{}]]` in contrast collapses all other axes into one, i.e.
     ///   the encoded array is two-dimensional
     pub axes: Vec<AxisGroup>,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/swizzle-reshape/src/lib.rs
+++ b/codecs/swizzle-reshape/src/lib.rs
@@ -26,7 +26,7 @@ use std::{
 use ndarray::{Array, ArrayBase, ArrayView, ArrayViewMut, Data, IxDyn};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{
@@ -63,6 +63,9 @@ pub struct SwizzleReshapeCodec {
     /// - `[[0], [{}]]` in contrast collapses all other axes into one, i.e.
     ///   the encoded array is two-dimensional
     pub axes: Vec<AxisGroup>,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/codecs/swizzle-reshape/src/lib.rs
+++ b/codecs/swizzle-reshape/src/lib.rs
@@ -64,8 +64,8 @@ pub struct SwizzleReshapeCodec {
     ///   the encoded array is two-dimensional
     pub axes: Vec<AxisGroup>,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/codecs/sz3/Cargo.toml
+++ b/codecs/sz3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-sz3"
-version = "0.5.0"
+version = "0.6.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -24,7 +24,7 @@ use std::{borrow::Cow, fmt};
 use ndarray::{Array, Array1, ArrayBase, Data, Dimension, ShapeError};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -37,6 +37,8 @@ use ::zstd_sys as _;
 #[cfg(test)]
 use ::serde_json as _;
 
+type Sz3CodecVersion = StaticCodecVersion<0, 1, 0>;
+
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 // serde cannot deny unknown fields because of the flatten
 #[schemars(deny_unknown_fields)]
@@ -48,6 +50,9 @@ pub struct Sz3Codec {
     /// SZ3 error bound
     #[serde(flatten)]
     pub error_bound: Sz3ErrorBound,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: Sz3CodecVersion,
 }
 
 /// SZ3 error bound
@@ -336,6 +341,7 @@ pub fn compress<T: Sz3Element, S: Data<Elem = T>, D: Dimension>(
         &CompressionHeader {
             dtype: <T as Sz3Element>::DTYPE,
             shape: Cow::Borrowed(data.shape()),
+            version: StaticCodecVersion,
         },
         Vec::new(),
     )
@@ -665,6 +671,7 @@ struct CompressionHeader<'a> {
     dtype: Sz3DType,
     #[serde(borrow)]
     shape: Cow<'a, [usize]>,
+    version: Sz3CodecVersion,
 }
 
 /// Dtypes that SZ3 can compress and decompress

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -50,7 +50,7 @@ pub struct Sz3Codec {
     /// SZ3 error bound
     #[serde(flatten)]
     pub error_bound: Sz3ErrorBound,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: Sz3CodecVersion,
 }

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -228,7 +228,7 @@ impl Codec for Sz3Codec {
 }
 
 impl StaticCodec for Sz3Codec {
-    const CODEC_ID: &'static str = "sz3";
+    const CODEC_ID: &'static str = "sz3.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/sz3/src/lib.rs
+++ b/codecs/sz3/src/lib.rs
@@ -51,8 +51,8 @@ pub struct Sz3Codec {
     #[serde(flatten)]
     pub error_bound: Sz3ErrorBound,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: Sz3CodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: Sz3CodecVersion,
 }
 
 /// SZ3 error bound

--- a/codecs/sz3/tests/schema.json
+++ b/codecs/sz3/tests/schema.json
@@ -109,6 +109,12 @@
       ],
       "description": "Predictor",
       "default": "cubic-interpolation-lorenzo"
+    },
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
     }
   },
   "unevaluatedProperties": false,

--- a/codecs/sz3/tests/schema.json
+++ b/codecs/sz3/tests/schema.json
@@ -113,7 +113,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/tthresh/Cargo.toml
+++ b/codecs/tthresh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-tthresh"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/tthresh/src/lib.rs
+++ b/codecs/tthresh/src/lib.rs
@@ -23,7 +23,7 @@ use ndarray::{Array, Array1, ArrayBase, Data, Dimension, ShapeError};
 use num_traits::Float;
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -40,6 +40,9 @@ pub struct TthreshCodec {
     /// tthresh error bound
     #[serde(flatten)]
     pub error_bound: TthreshErrorBound,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<0, 1, 0>,
 }
 
 /// tthresh error bound

--- a/codecs/tthresh/src/lib.rs
+++ b/codecs/tthresh/src/lib.rs
@@ -41,8 +41,8 @@ pub struct TthreshCodec {
     #[serde(flatten)]
     pub error_bound: TthreshErrorBound,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<0, 1, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<0, 1, 0>,
 }
 
 /// tthresh error bound

--- a/codecs/tthresh/src/lib.rs
+++ b/codecs/tthresh/src/lib.rs
@@ -122,7 +122,7 @@ impl Codec for TthreshCodec {
 }
 
 impl StaticCodec for TthreshCodec {
-    const CODEC_ID: &'static str = "tthresh";
+    const CODEC_ID: &'static str = "tthresh.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/tthresh/src/lib.rs
+++ b/codecs/tthresh/src/lib.rs
@@ -40,7 +40,7 @@ pub struct TthreshCodec {
     /// tthresh error bound
     #[serde(flatten)]
     pub error_bound: TthreshErrorBound,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<0, 1, 0>,
 }

--- a/codecs/tthresh/tests/schema.json
+++ b/codecs/tthresh/tests/schema.json
@@ -65,7 +65,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/tthresh/tests/schema.json
+++ b/codecs/tthresh/tests/schema.json
@@ -61,6 +61,14 @@
     }
   ],
   "description": "Codec providing compression using tthresh",
+  "properties": {
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
+    }
+  },
   "title": "TthreshCodec",
   "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/codecs/uniform-noise/Cargo.toml
+++ b/codecs/uniform-noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-uniform-noise"
-version = "0.2.1"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -92,7 +92,7 @@ impl Codec for UniformNoiseCodec {
 }
 
 impl StaticCodec for UniformNoiseCodec {
-    const CODEC_ID: &'static str = "uniform-noise";
+    const CODEC_ID: &'static str = "uniform-noise.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -23,7 +23,7 @@ use ndarray::{Array, ArrayBase, Data, Dimension};
 use num_traits::Float;
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use rand::{
     distributions::{Distribution, Open01},
@@ -50,6 +50,9 @@ pub struct UniformNoiseCodec {
     pub scale: f64,
     /// Seed for the random noise generator
     pub seed: u64,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for UniformNoiseCodec {

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -51,8 +51,8 @@ pub struct UniformNoiseCodec {
     /// Seed for the random noise generator
     pub seed: u64,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: StaticCodecVersion<1, 0, 0>,
+    #[serde(default, rename = "_version")]
+    pub version: StaticCodecVersion<1, 0, 0>,
 }
 
 impl Codec for UniformNoiseCodec {

--- a/codecs/uniform-noise/src/lib.rs
+++ b/codecs/uniform-noise/src/lib.rs
@@ -50,7 +50,7 @@ pub struct UniformNoiseCodec {
     pub scale: f64,
     /// Seed for the random noise generator
     pub seed: u64,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: StaticCodecVersion<1, 0, 0>,
 }

--- a/codecs/zfp-classic/Cargo.toml
+++ b/codecs/zfp-classic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp-classic"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zfp-classic/Cargo.toml
+++ b/codecs/zfp-classic/Cargo.toml
@@ -25,6 +25,9 @@ serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 zfp-sys = { workspace = true, features = ["static"] }
 
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }
+
 [lints]
 workspace = true
 

--- a/codecs/zfp-classic/Cargo.toml
+++ b/codecs/zfp-classic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp-classic"
-version = "0.3.0"
+version = "0.3.1"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zfp-classic/src/ffi.rs
+++ b/codecs/zfp-classic/src/ffi.rs
@@ -317,7 +317,7 @@ impl ZfpDecompressionStreamWithHeader<'_> {
                     shape: shape.to_vec(),
                 })
             }
-        };
+        }
 
         unsafe {
             zfp_sys::zfp_field_set_pointer(

--- a/codecs/zfp-classic/src/lib.rs
+++ b/codecs/zfp-classic/src/lib.rs
@@ -54,7 +54,7 @@ pub struct ZfpClassicCodec {
     /// ZFP compression mode
     #[serde(flatten)]
     pub mode: ZfpCompressionMode,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: ZfpClassicCodecVersion,
 }

--- a/codecs/zfp-classic/src/lib.rs
+++ b/codecs/zfp-classic/src/lib.rs
@@ -169,7 +169,7 @@ impl Codec for ZfpClassicCodec {
 }
 
 impl StaticCodec for ZfpClassicCodec {
-    const CODEC_ID: &'static str = "zfp-classic";
+    const CODEC_ID: &'static str = "zfp-classic.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/zfp-classic/src/lib.rs
+++ b/codecs/zfp-classic/src/lib.rs
@@ -39,6 +39,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg(test)]
+use ::serde_json as _;
+
 mod ffi;
 
 type ZfpClassicCodecVersion = StaticCodecVersion<0, 1, 0>;

--- a/codecs/zfp-classic/src/lib.rs
+++ b/codecs/zfp-classic/src/lib.rs
@@ -55,8 +55,8 @@ pub struct ZfpClassicCodec {
     #[serde(flatten)]
     pub mode: ZfpCompressionMode,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: ZfpClassicCodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: ZfpClassicCodecVersion,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/codecs/zfp-classic/tests/config.rs
+++ b/codecs/zfp-classic/tests/config.rs
@@ -1,0 +1,101 @@
+#![expect(missing_docs)]
+
+use ::{
+    ndarray as _, postcard as _, schemars as _, thiserror as _,
+    zfp_sys as _,
+};
+
+use numcodecs::StaticCodec;
+use numcodecs_zfp_classic::{ZfpClassicCodec, ZfpCompressionMode};
+use serde::Deserialize;
+use serde_json::json;
+
+#[test]
+#[should_panic(expected = "missing field `mode`")]
+fn empty_config() {
+    let _ = ZfpClassicCodec::from_config(Deserialize::deserialize(json!({})).unwrap());
+}
+
+#[test]
+fn expert_config() {
+    let codec = ZfpClassicCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "expert",
+            "min_bits": 1,
+            "max_bits": 4,
+            "max_prec": 2,
+            "min_exp": 3,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::Expert {
+            min_bits: 1,
+            max_bits: 4,
+            max_prec: 2,
+            min_exp: 3,
+        }
+    ));
+}
+
+#[test]
+fn fixed_rate_config() {
+    let codec = ZfpClassicCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "fixed-rate",
+            "rate": 4.0,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::FixedRate { rate: 4.0 }
+    ));
+}
+
+#[test]
+fn fixed_precision_config() {
+    let codec = ZfpClassicCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "fixed-precision",
+            "precision": 4,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::FixedPrecision { precision: 4 }
+    ));
+}
+
+#[test]
+fn fixed_accuracy_config() {
+    let codec = ZfpClassicCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "fixed-accuracy",
+            "tolerance": 0.5,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::FixedAccuracy { tolerance: 0.5 }
+    ));
+}
+
+#[test]
+fn reversible_config() {
+    let codec = ZfpClassicCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "reversible",
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(codec.mode, ZfpCompressionMode::Reversible));
+}

--- a/codecs/zfp-classic/tests/config.rs
+++ b/codecs/zfp-classic/tests/config.rs
@@ -1,9 +1,6 @@
 #![expect(missing_docs)]
 
-use ::{
-    ndarray as _, postcard as _, schemars as _, thiserror as _,
-    zfp_sys as _,
-};
+use ::{ndarray as _, postcard as _, schemars as _, thiserror as _, zfp_sys as _};
 
 use numcodecs::StaticCodec;
 use numcodecs_zfp_classic::{ZfpClassicCodec, ZfpCompressionMode};

--- a/codecs/zfp-classic/tests/schema.json
+++ b/codecs/zfp-classic/tests/schema.json
@@ -1,0 +1,128 @@
+{
+  "type": "object",
+  "unevaluatedProperties": false,
+  "oneOf": [
+    {
+      "type": "object",
+      "description": "The most general mode, which can describe all four other modes",
+      "properties": {
+        "min_bits": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Minimum number of compressed bits used to represent a block"
+        },
+        "max_bits": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Maximum number of bits used to represent a block"
+        },
+        "max_prec": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Maximum number of bit planes encoded"
+        },
+        "min_exp": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Smallest absolute bit plane number encoded.\n\n This parameter applies to floating-point data only and is ignored\n for integer data."
+        },
+        "mode": {
+          "type": "string",
+          "const": "expert"
+        }
+      },
+      "required": [
+        "mode",
+        "min_bits",
+        "max_bits",
+        "max_prec",
+        "min_exp"
+      ]
+    },
+    {
+      "type": "object",
+      "description": "In fixed-rate mode, each d-dimensional compressed block of `$4^d$`\n values is stored using a fixed number of bits. This number of\n compressed bits per block is amortized over the `$4^d$` values to give\n a rate of `$rate = \\frac{maxbits}{4^d}$` in bits per value.",
+      "properties": {
+        "rate": {
+          "type": "number",
+          "format": "double",
+          "description": "Rate in bits per value"
+        },
+        "mode": {
+          "type": "string",
+          "const": "fixed-rate"
+        }
+      },
+      "required": [
+        "mode",
+        "rate"
+      ]
+    },
+    {
+      "type": "object",
+      "description": "In fixed-precision mode, the number of bits used to encode a block may\n vary, but the number of bit planes (the precision) encoded for the\n transform coefficients is fixed.",
+      "properties": {
+        "precision": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Number of bit planes encoded"
+        },
+        "mode": {
+          "type": "string",
+          "const": "fixed-precision"
+        }
+      },
+      "required": [
+        "mode",
+        "precision"
+      ]
+    },
+    {
+      "type": "object",
+      "description": "In fixed-accuracy mode, all transform coefficient bit planes up to a\n minimum bit plane number are encoded. The smallest absolute bit plane\n number is chosen such that\n `$minexp = \\text{floor}(\\log_{2}(tolerance))$`.",
+      "properties": {
+        "tolerance": {
+          "type": "number",
+          "format": "double",
+          "description": "Absolute error tolerance"
+        },
+        "mode": {
+          "type": "string",
+          "const": "fixed-accuracy"
+        }
+      },
+      "required": [
+        "mode",
+        "tolerance"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "reversible"
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "description": "Lossless per-block compression that preserves integer and floating point\n bit patterns."
+    }
+  ],
+  "description": "Codec providing compression using ZFP (classic)",
+  "properties": {
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
+    }
+  },
+  "title": "ZfpClassicCodec",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/codecs/zfp-classic/tests/schema.json
+++ b/codecs/zfp-classic/tests/schema.json
@@ -119,7 +119,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/zfp-classic/tests/schema.rs
+++ b/codecs/zfp-classic/tests/schema.rs
@@ -1,0 +1,23 @@
+#![expect(missing_docs)]
+
+use ::{
+    ndarray as _, postcard as _, schemars as _, serde as _, serde_json as _, thiserror as _,
+    zfp_sys as _,
+};
+
+use numcodecs::{DynCodecType, StaticCodecType};
+use numcodecs_zfp_classic::ZfpClassicCodec;
+
+#[test]
+fn schema() {
+    let schema = format!(
+        "{:#}",
+        StaticCodecType::<ZfpClassicCodec>::of()
+            .codec_config_schema()
+            .to_value()
+    );
+
+    if schema != include_str!("schema.json") {
+        panic!("ZfpClassic schema has changed\n===\n{schema}\n===");
+    }
+}

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp"
-version = "0.4.0"
+version = "0.5.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp"
-version = "0.5.0"
+version = "0.5.1"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -25,6 +25,9 @@ serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true }
 zfp-sys = { workspace = true, features = ["static", "round-tight-error"] }
 
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }
+
 [lints]
 workspace = true
 

--- a/codecs/zfp/src/ffi.rs
+++ b/codecs/zfp/src/ffi.rs
@@ -314,7 +314,7 @@ impl ZfpDecompressionStreamWithHeader<'_> {
                     shape: shape.to_vec(),
                 })
             }
-        };
+        }
 
         unsafe {
             zfp_sys::zfp_field_set_pointer(

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -60,8 +60,8 @@ pub struct ZfpCodec {
     #[serde(flatten)]
     pub mode: ZfpCompressionMode,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: ZfpCodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: ZfpCodecVersion,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -44,6 +44,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg(test)]
+use ::serde_json as _;
+
 mod ffi;
 
 type ZfpCodecVersion = StaticCodecVersion<0, 1, 0>;

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -38,7 +38,7 @@ use std::{borrow::Cow, fmt};
 use ndarray::{Array, Array1, ArrayView, Dimension, Zip};
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -46,12 +46,19 @@ use thiserror::Error;
 
 mod ffi;
 
+type ZfpCodecVersion = StaticCodecVersion<0, 1, 0>;
+
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(transparent)]
+// serde cannot deny unknown fields because of the flatten
+#[schemars(deny_unknown_fields)]
 /// Codec providing compression using ZFP
 pub struct ZfpCodec {
     /// ZFP compression mode
+    #[serde(flatten)]
     pub mode: ZfpCompressionMode,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: ZfpCodecVersion,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -293,6 +300,7 @@ pub fn compress<T: ffi::ZfpCompressible, D: Dimension>(
         &CompressionHeader {
             dtype: <T as ffi::ZfpCompressible>::D_TYPE,
             shape: Cow::Borrowed(data.shape()),
+            version: StaticCodecVersion,
         },
         Vec::new(),
     )
@@ -441,6 +449,7 @@ struct CompressionHeader<'a> {
     dtype: ZfpDType,
     #[serde(borrow)]
     shape: Cow<'a, [usize]>,
+    version: ZfpCodecVersion,
 }
 
 /// Dtypes that Zfp can compress and decompress

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -174,7 +174,7 @@ impl Codec for ZfpCodec {
 }
 
 impl StaticCodec for ZfpCodec {
-    const CODEC_ID: &'static str = "zfp";
+    const CODEC_ID: &'static str = "zfp.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/zfp/src/lib.rs
+++ b/codecs/zfp/src/lib.rs
@@ -59,7 +59,7 @@ pub struct ZfpCodec {
     /// ZFP compression mode
     #[serde(flatten)]
     pub mode: ZfpCompressionMode,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: ZfpCodecVersion,
 }

--- a/codecs/zfp/tests/config.rs
+++ b/codecs/zfp/tests/config.rs
@@ -1,9 +1,6 @@
 #![expect(missing_docs)]
 
-use ::{
-    ndarray as _, postcard as _, schemars as _, thiserror as _,
-    zfp_sys as _,
-};
+use ::{ndarray as _, postcard as _, schemars as _, thiserror as _, zfp_sys as _};
 
 use numcodecs::StaticCodec;
 use numcodecs_zfp::{ZfpCodec, ZfpCompressionMode};

--- a/codecs/zfp/tests/config.rs
+++ b/codecs/zfp/tests/config.rs
@@ -1,0 +1,101 @@
+#![expect(missing_docs)]
+
+use ::{
+    ndarray as _, postcard as _, schemars as _, thiserror as _,
+    zfp_sys as _,
+};
+
+use numcodecs::StaticCodec;
+use numcodecs_zfp::{ZfpCodec, ZfpCompressionMode};
+use serde::Deserialize;
+use serde_json::json;
+
+#[test]
+#[should_panic(expected = "missing field `mode`")]
+fn empty_config() {
+    let _ = ZfpCodec::from_config(Deserialize::deserialize(json!({})).unwrap());
+}
+
+#[test]
+fn expert_config() {
+    let codec = ZfpCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "expert",
+            "min_bits": 1,
+            "max_bits": 4,
+            "max_prec": 2,
+            "min_exp": 3,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::Expert {
+            min_bits: 1,
+            max_bits: 4,
+            max_prec: 2,
+            min_exp: 3,
+        }
+    ));
+}
+
+#[test]
+fn fixed_rate_config() {
+    let codec = ZfpCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "fixed-rate",
+            "rate": 4.0,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::FixedRate { rate: 4.0 }
+    ));
+}
+
+#[test]
+fn fixed_precision_config() {
+    let codec = ZfpCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "fixed-precision",
+            "precision": 4,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::FixedPrecision { precision: 4 }
+    ));
+}
+
+#[test]
+fn fixed_accuracy_config() {
+    let codec = ZfpCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "fixed-accuracy",
+            "tolerance": 0.5,
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(
+        codec.mode,
+        ZfpCompressionMode::FixedAccuracy { tolerance: 0.5 }
+    ));
+}
+
+#[test]
+fn reversible_config() {
+    let codec = ZfpCodec::from_config(
+        Deserialize::deserialize(json!({
+            "mode": "reversible",
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(codec.mode, ZfpCompressionMode::Reversible));
+}

--- a/codecs/zfp/tests/schema.json
+++ b/codecs/zfp/tests/schema.json
@@ -119,7 +119,7 @@
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
       "default": "0.1.0"
     }
   },

--- a/codecs/zfp/tests/schema.json
+++ b/codecs/zfp/tests/schema.json
@@ -1,0 +1,128 @@
+{
+  "type": "object",
+  "unevaluatedProperties": false,
+  "oneOf": [
+    {
+      "type": "object",
+      "description": "The most general mode, which can describe all four other modes",
+      "properties": {
+        "min_bits": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Minimum number of compressed bits used to represent a block"
+        },
+        "max_bits": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Maximum number of bits used to represent a block"
+        },
+        "max_prec": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Maximum number of bit planes encoded"
+        },
+        "min_exp": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Smallest absolute bit plane number encoded.\n\n This parameter applies to floating-point data only and is ignored\n for integer data."
+        },
+        "mode": {
+          "type": "string",
+          "const": "expert"
+        }
+      },
+      "required": [
+        "mode",
+        "min_bits",
+        "max_bits",
+        "max_prec",
+        "min_exp"
+      ]
+    },
+    {
+      "type": "object",
+      "description": "In fixed-rate mode, each d-dimensional compressed block of `$4^d$`\n values is stored using a fixed number of bits. This number of\n compressed bits per block is amortized over the `$4^d$` values to give\n a rate of `$rate = \\frac{maxbits}{4^d}$` in bits per value.",
+      "properties": {
+        "rate": {
+          "type": "number",
+          "format": "double",
+          "description": "Rate in bits per value"
+        },
+        "mode": {
+          "type": "string",
+          "const": "fixed-rate"
+        }
+      },
+      "required": [
+        "mode",
+        "rate"
+      ]
+    },
+    {
+      "type": "object",
+      "description": "In fixed-precision mode, the number of bits used to encode a block may\n vary, but the number of bit planes (the precision) encoded for the\n transform coefficients is fixed.",
+      "properties": {
+        "precision": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "description": "Number of bit planes encoded"
+        },
+        "mode": {
+          "type": "string",
+          "const": "fixed-precision"
+        }
+      },
+      "required": [
+        "mode",
+        "precision"
+      ]
+    },
+    {
+      "type": "object",
+      "description": "In fixed-accuracy mode, all transform coefficient bit planes up to a\n minimum bit plane number are encoded. The smallest absolute bit plane\n number is chosen such that\n `$minexp = \\text{floor}(\\log_{2}(tolerance))$`.",
+      "properties": {
+        "tolerance": {
+          "type": "number",
+          "format": "double",
+          "description": "Absolute error tolerance"
+        },
+        "mode": {
+          "type": "string",
+          "const": "fixed-accuracy"
+        }
+      },
+      "required": [
+        "mode",
+        "tolerance"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "reversible"
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "description": "Lossless per-block compression that preserves integer and floating point\n bit patterns."
+    }
+  ],
+  "description": "Codec providing compression using ZFP",
+  "properties": {
+    "_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "The codec's version. Do not provide this parameter explicitly.",
+      "default": "0.1.0"
+    }
+  },
+  "title": "ZfpCodec",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/codecs/zfp/tests/schema.rs
+++ b/codecs/zfp/tests/schema.rs
@@ -1,0 +1,23 @@
+#![expect(missing_docs)]
+
+use ::{
+    ndarray as _, postcard as _, schemars as _, serde as _, serde_json as _, thiserror as _,
+    zfp_sys as _,
+};
+
+use numcodecs::{DynCodecType, StaticCodecType};
+use numcodecs_zfp::ZfpCodec;
+
+#[test]
+fn schema() {
+    let schema = format!(
+        "{:#}",
+        StaticCodecType::<ZfpCodec>::of()
+            .codec_config_schema()
+            .to_value()
+    );
+
+    if schema != include_str!("schema.json") {
+        panic!("Zfp schema has changed\n===\n{schema}\n===");
+    }
+}

--- a/codecs/zlib/Cargo.toml
+++ b/codecs/zlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zlib"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zlib/src/lib.rs
+++ b/codecs/zlib/src/lib.rs
@@ -24,12 +24,14 @@ use std::borrow::Cow;
 use ndarray::Array1;
 use numcodecs::{
     AnyArray, AnyArrayAssignError, AnyArrayDType, AnyArrayView, AnyArrayViewMut, AnyCowArray,
-    Codec, StaticCodec, StaticCodecConfig,
+    Codec, StaticCodec, StaticCodecConfig, StaticCodecVersion,
 };
 use schemars::{JsonSchema, JsonSchema_repr};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
+
+type ZlibCodecVersion = StaticCodecVersion<0, 1, 0>;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -39,6 +41,9 @@ pub struct ZlibCodec {
     ///
     /// The level ranges from 0, no compression, to 9, best compression.
     pub level: ZlibLevel,
+    /// The codec's version. Do not provide this parameter explicitly.
+    #[serde(default)]
+    pub _version: ZlibCodecVersion,
 }
 
 #[derive(Copy, Clone, Serialize_repr, Deserialize_repr, JsonSchema_repr)]
@@ -200,6 +205,7 @@ pub fn compress(array: AnyArrayView, level: ZlibLevel) -> Result<Vec<u8>, ZlibCo
         &CompressionHeader {
             dtype: array.dtype(),
             shape: Cow::Borrowed(array.shape()),
+            version: StaticCodecVersion,
         },
         Vec::new(),
     )
@@ -362,4 +368,5 @@ struct CompressionHeader<'a> {
     dtype: AnyArrayDType,
     #[serde(borrow)]
     shape: Cow<'a, [usize]>,
+    version: ZlibCodecVersion,
 }

--- a/codecs/zlib/src/lib.rs
+++ b/codecs/zlib/src/lib.rs
@@ -41,7 +41,7 @@ pub struct ZlibCodec {
     ///
     /// The level ranges from 0, no compression, to 9, best compression.
     pub level: ZlibLevel,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: ZlibCodecVersion,
 }

--- a/codecs/zlib/src/lib.rs
+++ b/codecs/zlib/src/lib.rs
@@ -42,8 +42,8 @@ pub struct ZlibCodec {
     /// The level ranges from 0, no compression, to 9, best compression.
     pub level: ZlibLevel,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: ZlibCodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: ZlibCodecVersion,
 }
 
 #[derive(Copy, Clone, Serialize_repr, Deserialize_repr, JsonSchema_repr)]

--- a/codecs/zlib/src/lib.rs
+++ b/codecs/zlib/src/lib.rs
@@ -106,7 +106,7 @@ impl Codec for ZlibCodec {
 }
 
 impl StaticCodec for ZlibCodec {
-    const CODEC_ID: &'static str = "zlib";
+    const CODEC_ID: &'static str = "zlib.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/zstd/Cargo.toml
+++ b/codecs/zstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zstd"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zstd/src/lib.rs
+++ b/codecs/zstd/src/lib.rs
@@ -43,8 +43,8 @@ pub struct ZstdCodec {
     /// The level ranges from small (fastest) to large (best compression).
     pub level: ZstdLevel,
     /// The codec's version. Do not provide this parameter explicitly.
-    #[serde(default)]
-    pub _version: ZstdCodecVersion,
+    #[serde(default, rename = "_version")]
+    pub version: ZstdCodecVersion,
 }
 
 impl Codec for ZstdCodec {

--- a/codecs/zstd/src/lib.rs
+++ b/codecs/zstd/src/lib.rs
@@ -88,7 +88,7 @@ impl Codec for ZstdCodec {
 }
 
 impl StaticCodec for ZstdCodec {
-    const CODEC_ID: &'static str = "zstd";
+    const CODEC_ID: &'static str = "zstd.rs";
 
     type Config<'de> = Self;
 

--- a/codecs/zstd/src/lib.rs
+++ b/codecs/zstd/src/lib.rs
@@ -42,7 +42,7 @@ pub struct ZstdCodec {
     ///
     /// The level ranges from small (fastest) to large (best compression).
     pub level: ZstdLevel,
-    /// The codec's version. Do not provide this parameter explicitly.
+    /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: ZstdCodecVersion,
 }

--- a/crates/numcodecs-python/Cargo.toml
+++ b/crates/numcodecs-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-python"
-version = "0.5.0"
+version = "0.6.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/crates/numcodecs-python/src/adapter.rs
+++ b/crates/numcodecs-python/src/adapter.rs
@@ -383,7 +383,7 @@ impl PyCodecAdapter {
                 "unsupported dtype {} of array-like",
                 ndarray.dtype()
             )));
-        };
+        }
 
         Err(PyTypeError::new_err(format!(
             "mismatching dtype {} of array-like, expected {}",

--- a/crates/numcodecs-python/src/export.rs
+++ b/crates/numcodecs-python/src/export.rs
@@ -38,7 +38,7 @@ pub fn export_codec_class<'py, T: DynCodecType<Codec: Ungil> + Ungil>(
 ) -> Result<Bound<'py, PyCodecClass>, PyErr> {
     let codec_id = String::from(ty.codec_id());
 
-    // special case for codec ids ending in .rs (we're writing Rust codecs after all)
+    // special case for codec ids ending in .rs (we're exporting Rust codecs after all)
     let codec_id_no_rs = codec_id.strip_suffix(".rs").unwrap_or(&codec_id);
     // derive the codec name, without any prefix
     let codec_name = match codec_id_no_rs.rsplit_once('.') {

--- a/crates/numcodecs-python/src/schema.rs
+++ b/crates/numcodecs-python/src/schema.rs
@@ -154,6 +154,7 @@ pub fn docs_from_schema(schema: &Schema) -> Option<String> {
             docs.push_str(", optional");
         }
 
+        #[expect(clippy::format_push_string)] // FIXME
         if let Some(default) = parameter.default {
             docs.push_str(", default = ");
             docs.push_str(&format!("{default}"));
@@ -197,6 +198,7 @@ pub fn signature_from_schema(schema: &Schema) -> String {
         signature.push_str(", ");
         signature.push_str(parameter.name);
 
+        #[expect(clippy::format_push_string)] // FIXME
         if let Some(default) = parameter.default {
             signature.push('=');
             signature.push_str(&format!("{default}"));
@@ -509,6 +511,7 @@ impl<'a> VariantParameter<'a> {
         if let Some(tag_docs) = self.tag_docs {
             let mut docs = String::new();
 
+            #[expect(clippy::format_push_string)] // FIXME
             for (tag, tag_docs) in tag_docs {
                 docs.push_str(" - ");
                 docs.push_str(&format!("{tag}"));

--- a/crates/numcodecs-python/tests/export.rs
+++ b/crates/numcodecs-python/tests/export.rs
@@ -31,7 +31,7 @@ fn export() -> Result<(), PyErr> {
 
         // create a codec using registry lookup
         let codec = PyCodecRegistry::get_codec(config.as_borrowed())?;
-        assert_eq!(codec.class.as_type().name()?.to_cow()?, "Negate");
+        assert_eq!(codec.class().as_type().name()?.to_cow()?, "Negate");
         assert_eq!(codec.class().codec_id()?, "negate.rs");
 
         // check the codec's config

--- a/crates/numcodecs-python/tests/export.rs
+++ b/crates/numcodecs-python/tests/export.rs
@@ -171,7 +171,7 @@ impl Codec for NegateCodec {
 }
 
 impl StaticCodec for NegateCodec {
-    const CODEC_ID: &'static str = "negate";
+    const CODEC_ID: &'static str = "negate.rs";
 
     type Config<'de> = Self;
 

--- a/crates/numcodecs-python/tests/export.rs
+++ b/crates/numcodecs-python/tests/export.rs
@@ -27,11 +27,12 @@ fn export() -> Result<(), PyErr> {
         )?;
 
         let config = PyDict::new(py);
-        config.set_item("id", "negate")?;
+        config.set_item("id", "negate.rs")?;
 
         // create a codec using registry lookup
         let codec = PyCodecRegistry::get_codec(config.as_borrowed())?;
-        assert_eq!(codec.class().codec_id()?, "negate");
+        assert_eq!(codec.class.as_type().name()?.to_cow()?, "Negate");
+        assert_eq!(codec.class().codec_id()?, "negate.rs");
 
         // check the codec's config
         let config = codec.get_config()?;
@@ -42,7 +43,7 @@ fn export() -> Result<(), PyErr> {
                 .map(|i| i.extract::<String>())
                 .transpose()?
                 .as_deref(),
-            Some("negate")
+            Some("negate.rs")
         );
 
         // encode and decode data with the codec

--- a/crates/numcodecs-wasm-host/src/component.rs
+++ b/crates/numcodecs-wasm-host/src/component.rs
@@ -103,12 +103,14 @@ impl WasmCodecComponent {
 
 /// Methods for implementing the [`DynCodecType`][numcodecs::DynCodecType] trait
 impl WasmCodecComponent {
+    #[allow(clippy::missing_const_for_fn)] // FIXME: false positive, has Arc deref
     /// Codec identifier.
     #[must_use]
     pub fn codec_id(&self) -> &str {
         &self.codec_id
     }
 
+    #[allow(clippy::missing_const_for_fn)] // FIXME: false positive, has Arc deref
     /// JSON schema for the codec's configuration.
     #[must_use]
     pub fn codec_config_schema(&self) -> &Schema {

--- a/crates/numcodecs/Cargo.toml
+++ b/crates/numcodecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/crates/numcodecs/Cargo.toml
+++ b/crates/numcodecs/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["numcodecs", "compression", "encoding"]
 [dependencies]
 ndarray = { workspace = true }
 schemars = { workspace = true, features = ["derive"] }
+semver = { workspace = true, features = ["std", "serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -300,11 +300,11 @@ pub fn codec_from_config_with_id<'de, T: DynCodecType, D: Deserializer<'de>>(
 }
 
 /// Marker type that represents the semantic version of a codec.
-/// 
+///
 /// The codec's version can be decoupled from its implementation version to
 /// allow implementation changes that have no effect on the codec's semantics
 /// or encoded representation.
-/// 
+///
 /// `StaticCodecVersion`s serialize transparently to their equivalent
 /// [`Version`]s. On deserialization, the deserialized [`Version`] is checked
 /// to be compatible (`^`) with the `StaticCodecVersion`, i.e. the
@@ -319,39 +319,54 @@ impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> StaticCodecVersion<MA
     }
 }
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Clone for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Clone
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Copy for StaticCodecVersion<MAJOR, MINOR, PATCH> {}
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Copy
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
+}
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> fmt::Debug for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> fmt::Debug
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         <semver::Version as fmt::Debug>::fmt(&Self::version(), fmt)
     }
 }
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> fmt::Display for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> fmt::Display
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         <semver::Version as fmt::Display>::fmt(&Self::version(), fmt)
     }
 }
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Default for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Default
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn default() -> Self {
         Self
     }
 }
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Serialize for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Serialize
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         Self::version().serialize(serializer)
     }
 }
 
-impl<'de, const MAJOR: u64, const MINOR: u64, const PATCH: u64> Deserialize<'de> for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<'de, const MAJOR: u64, const MINOR: u64, const PATCH: u64> Deserialize<'de>
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let version = Version::deserialize(deserializer)?;
 
@@ -366,14 +381,18 @@ impl<'de, const MAJOR: u64, const MINOR: u64, const PATCH: u64> Deserialize<'de>
         };
 
         if !requirement.matches(&Self::version()) {
-            return Err(serde::de::Error::custom(format!("{Self} does not fulfil {requirement}")));
+            return Err(serde::de::Error::custom(format!(
+                "{Self} does not fulfil {requirement}"
+            )));
         }
 
         Ok(Self)
     }
 }
 
-impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> JsonSchema for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> JsonSchema
+    for StaticCodecVersion<MAJOR, MINOR, PATCH>
+{
     fn schema_name() -> Cow<'static, str> {
         Cow::Borrowed("StaticCodecVersion")
     }

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, error::Error, marker::PhantomData};
+use std::{borrow::Cow, error::Error, fmt, marker::PhantomData};
 
-use schemars::{generate::SchemaSettings, JsonSchema, Schema};
+use schemars::{generate::SchemaSettings, json_schema, JsonSchema, Schema, SchemaGenerator};
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
@@ -296,4 +297,96 @@ pub fn codec_from_config_with_id<'de, T: DynCodecType, D: Deserializer<'de>>(
 
     ty.codec_from_config(config)
         .map_err(serde::de::Error::custom)
+}
+
+/// Marker type that represents the semantic version of a codec.
+/// 
+/// The codec's version can be decoupled from its implementation version to
+/// allow implementation changes that have no effect on the codec's semantics
+/// or encoded representation.
+/// 
+/// `StaticCodecVersion`s serialize transparently to their equivalent
+/// [`Version`]s. On deserialization, the deserialized [`Version`] is checked
+/// to be compatible (`^`) with the `StaticCodecVersion`, i.e. the
+/// `StaticCodecVersion` must be of a the same or a newer compatible version.
+pub struct StaticCodecVersion<const MAJOR: u64, const MINOR: u64, const PATCH: u64>;
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    /// Extract the semantic version.
+    #[must_use]
+    pub const fn version() -> Version {
+        Version::new(MAJOR, MINOR, PATCH)
+    }
+}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Clone for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Copy for StaticCodecVersion<MAJOR, MINOR, PATCH> {}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> fmt::Debug for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        <semver::Version as fmt::Debug>::fmt(&Self::version(), fmt)
+    }
+}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> fmt::Display for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        <semver::Version as fmt::Display>::fmt(&Self::version(), fmt)
+    }
+}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Default for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Serialize for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Self::version().serialize(serializer)
+    }
+}
+
+impl<'de, const MAJOR: u64, const MINOR: u64, const PATCH: u64> Deserialize<'de> for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let version = Version::deserialize(deserializer)?;
+
+        let requirement = VersionReq {
+            comparators: vec![semver::Comparator {
+                op: semver::Op::Caret,
+                major: version.major,
+                minor: Some(version.minor),
+                patch: Some(version.patch),
+                pre: version.pre,
+            }],
+        };
+
+        if !requirement.matches(&Self::version()) {
+            return Err(serde::de::Error::custom(format!("{Self} does not fulfil {requirement}")));
+        }
+
+        Ok(Self)
+    }
+}
+
+impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> JsonSchema for StaticCodecVersion<MAJOR, MINOR, PATCH> {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("StaticCodecVersion")
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed(concat!(module_path!(), "::", "StaticCodecVersion"))
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+            "description": "A semver.org compliant semantic version number.",
+        })
+    }
 }

--- a/crates/numcodecs/src/codec.rs
+++ b/crates/numcodecs/src/codec.rs
@@ -319,6 +319,7 @@ impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> StaticCodecVersion<MA
     }
 }
 
+#[expect(clippy::expl_impl_clone_on_copy)]
 impl<const MAJOR: u64, const MINOR: u64, const PATCH: u64> Clone
     for StaticCodecVersion<MAJOR, MINOR, PATCH>
 {

--- a/crates/numcodecs/src/lib.rs
+++ b/crates/numcodecs/src/lib.rs
@@ -28,7 +28,7 @@ pub use array::{
 };
 pub use codec::{
     codec_from_config_with_id, serialize_codec_config_with_id, Codec, DynCodec, DynCodecType,
-    StaticCodec, StaticCodecConfig, StaticCodecType,
+    StaticCodec, StaticCodecConfig, StaticCodecType, StaticCodecVersion,
 };
 
 mod sealed {

--- a/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
+++ b/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
@@ -105,9 +105,9 @@ for c in (repo_path / "codecs").iterdir():
     )
     subprocess.run(
         shlex.split(
-            f'uv run python3 -c "from {'numcodecs_wasm_' + templates['package_suffix']} '
-            f'import {templates['CodecName']} as Codec; '
-            f'assert Codec.codec_id == {templates['codec-id']!r}"'
+            f'uv run python3 -c "from {"numcodecs_wasm_" + templates["package_suffix"]} '
+            f'import {templates["CodecName"]} as Codec; '
+            f'assert Codec.codec_id == {templates["codec-id"]!r}"'
         ),
         check=True,
         cwd=staging_path,

--- a/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
+++ b/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
@@ -37,6 +37,7 @@ for c in (repo_path / "codecs").iterdir():
         "crate-version": toml.load(codec_crate_path / "Cargo.toml")["package"][
             "version"
         ],
+        "codec-id": f"{codec}.rs",
         "codec-path": "".join(c.title() for c in codec.split("-")) + "Codec",
         "CodecName": "".join(c.title() for c in codec.split("-")),
         "wasm-file": codec,
@@ -98,6 +99,15 @@ for c in (repo_path / "codecs").iterdir():
         shlex.split(
             f"uv run python3 {Path(__file__).parent / 'stub.py'} "
             f"{'numcodecs_wasm_' + templates['package_suffix']} src"
+        ),
+        check=True,
+        cwd=staging_path,
+    )
+    subprocess.run(
+        shlex.split(
+            f'uv run python3 -c "from {'numcodecs_wasm_' + templates['package_suffix']} '
+            f'import {templates['CodecName']} as Codec; '
+            f'assert Codec.codec_id == {templates['codec-id']!r}"'
         ),
         check=True,
         cwd=staging_path,

--- a/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
+++ b/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
@@ -107,7 +107,7 @@ for c in (repo_path / "codecs").iterdir():
         shlex.split(
             f'uv run python3 -c "from {"numcodecs_wasm_" + templates["package_suffix"]} '
             f'import {templates["CodecName"]} as Codec; '
-            f'assert Codec.codec_id == {templates["codec-id"]!r}"'
+            f'assert Codec.codec_id == {templates["codec-id"]!r}, Codec.codec_id"'
         ),
         check=True,
         cwd=staging_path,

--- a/py/numcodecs-wasm-template/pyproject.toml
+++ b/py/numcodecs-wasm-template/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "numcodecs-wasm~=0.1.1", # wasi 0.2.3
 ]
 
+[project.entry-points."numcodecs.codecs"]
+"%codec-id%" = "numcodecs_wasm_%package_suffix%:%CodecName%"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/py/numcodecs-wasm-template/pyproject.toml
+++ b/py/numcodecs-wasm-template/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 
 dependencies = [
-    "numcodecs-wasm~=0.1.1", # wasi 0.2.3
+    "numcodecs-wasm~=0.1.5", # wasi 0.2.3
 ]
 
 [project.entry-points."numcodecs.codecs"]

--- a/py/numcodecs-wasm/Cargo.toml
+++ b/py/numcodecs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-wasm"
-version = "0.1.4+wasi0.2.3"
+version = "0.1.5+wasi0.2.3"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/py/numcodecs-wasm/pyproject.toml
+++ b/py/numcodecs-wasm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "numcodecs_wasm"
-version = "0.1.4" # wasi 0.2.3
+version = "0.1.5" # wasi 0.2.3
 description = "numcodecs compression for codecs compiled to WebAssembly"
 
 authors = [{ name = "Juniper Tyree", email = "juniper.tyree@helsinki.fi" }]


### PR DESCRIPTION
This PR adds the `numcodecs.codecs` entry points to the `numcodecs_wasm_*` Python packages. As part of that, all codec's codec IDs are updates in breaking releases to be unique and no longer clash with some `numcodecs` builtin codecs.

Additionally, this PR also adds encoded format versions to the codec configs (and where possible also encoded headers) to ensure that only compatible versions of the codec try to decode encoded data. Notably, these format versions are independent of the Rust crate / Python package versions, which are updated more frequently. Array-to-array codecs generally start with v1.0.0, since there is little that can be changed about the format, while array-to-bytes codecs start with v0.1.0.