### PR TITLE
Bump zfp-sys to v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ wit-bindgen = { version = "0.42", default-features = false }
 wit-component = { version = "0.235", default-features = false }
 wit-parser = { version = "0.235", default-features = false }
 wyhash = { version = "0.6", default-features = false }
-zfp-sys = { version = "0.4.0", default-features = false }
+zfp-sys = { version = "0.4.1", default-features = false }
 zstd = { version = "0.13", default-features = false }
 zstd-sys = { version = "2.0.12", default-features = false }
 

--- a/codecs/zfp-classic/Cargo.toml
+++ b/codecs/zfp-classic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp-classic"
-version = "0.3.1"
+version = "0.3.2"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/zfp/Cargo.toml
+++ b/codecs/zfp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-zfp"
-version = "0.5.1"
+version = "0.5.2"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
zfp-sys v0.4.1 includes https://github.com/jvo203/zfp-sys/pull/7, which includes https://github.com/LLNL/zfp/pull/271, the fix for https://github.com/LLNL/zfp/pull/270