### PR TITLE
Use chunked encoding in EBCC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ numcodecs-wasm = { version = "0.2.4", path = "py/numcodecs-wasm", default-featur
 # workspace-internal codecs crates
 numcodecs-asinh = { version = "0.4", path = "codecs/asinh", default-features = false }
 numcodecs-bit-round = { version = "0.4", path = "codecs/bit-round", default-features = false }
-numcodecs-ebcc = { version = "0.1.1", path = "codecs/ebcc", default-features = false }
+numcodecs-ebcc = { version = "0.3", path = "codecs/ebcc", default-features = false }
 numcodecs-fixed-offset-scale = { version = "0.4", path = "codecs/fixed-offset-scale", default-features = false }
 numcodecs-fourier-network = { version = "0.3", path = "codecs/fourier-network", default-features = false }
 numcodecs-identity = { version = "0.4", path = "codecs/identity", default-features = false }
@@ -89,7 +89,7 @@ anyhow = { version = "1.0.93", default-features = false }
 burn = { version = "0.18", default-features = false }
 clap = { version = "4.6", default-features = false }
 convert_case = { version = "0.8", default-features = false }
-ebcc = { version = "0.2", default-features = false }
+ebcc = { version = "0.3.0-alpha", git = "https://github.com/juntyr/ebcc-rs.git", rev = "e695d8e", default-features = false }
 format_serde_error = { version = "0.3", default-features = false }
 indexmap = { version = "2.10", default-features = false }
 itertools = { version = "0.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = { version = "1.0.93", default-features = false }
 burn = { version = "0.18", default-features = false }
 clap = { version = "4.6", default-features = false }
 convert_case = { version = "0.8", default-features = false }
-ebcc = { version = "0.3.0-alpha", git = "https://github.com/juntyr/ebcc-rs.git", rev = "177a43d", default-features = false }
+ebcc = { version = "0.3.0-alpha", git = "https://github.com/juntyr/ebcc-rs.git", rev = "4d0315b", default-features = false }
 format_serde_error = { version = "0.3", default-features = false }
 indexmap = { version = "2.10", default-features = false }
 itertools = { version = "0.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ numcodecs-wasm = { version = "0.2.4", path = "py/numcodecs-wasm", default-featur
 # workspace-internal codecs crates
 numcodecs-asinh = { version = "0.4", path = "codecs/asinh", default-features = false }
 numcodecs-bit-round = { version = "0.4", path = "codecs/bit-round", default-features = false }
-numcodecs-ebcc = { version = "0.3", path = "codecs/ebcc", default-features = false }
+numcodecs-ebcc = { version = "0.3.0-alpha", path = "codecs/ebcc", default-features = false }
 numcodecs-fixed-offset-scale = { version = "0.4", path = "codecs/fixed-offset-scale", default-features = false }
 numcodecs-fourier-network = { version = "0.3", path = "codecs/fourier-network", default-features = false }
 numcodecs-identity = { version = "0.4", path = "codecs/identity", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = { version = "1.0.93", default-features = false }
 burn = { version = "0.18", default-features = false }
 clap = { version = "4.6", default-features = false }
 convert_case = { version = "0.8", default-features = false }
-ebcc = { version = "0.3.0-alpha", git = "https://github.com/juntyr/ebcc-rs.git", rev = "4d0315b", default-features = false }
+ebcc = { version = "0.3.0-alpha", default-features = false }
 format_serde_error = { version = "0.3", default-features = false }
 indexmap = { version = "2.10", default-features = false }
 itertools = { version = "0.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = { version = "1.0.93", default-features = false }
 burn = { version = "0.18", default-features = false }
 clap = { version = "4.6", default-features = false }
 convert_case = { version = "0.8", default-features = false }
-ebcc = { version = "0.3.0-alpha", git = "https://github.com/juntyr/ebcc-rs.git", rev = "e695d8e", default-features = false }
+ebcc = { version = "0.3.0-alpha", git = "https://github.com/juntyr/ebcc-rs.git", rev = "177a43d", default-features = false }
 format_serde_error = { version = "0.3", default-features = false }
 indexmap = { version = "2.10", default-features = false }
 itertools = { version = "0.14", default-features = false }

--- a/codecs/ebcc/Cargo.toml
+++ b/codecs/ebcc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-ebcc"
-version = "0.3.0"
+version = "0.3.0-alpha"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/ebcc/Cargo.toml
+++ b/codecs/ebcc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-ebcc"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/codecs/ebcc/src/lib.rs
+++ b/codecs/ebcc/src/lib.rs
@@ -34,7 +34,7 @@ use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-type EbccCodecVersion = StaticCodecVersion<0, 1, 0>;
+type EbccCodecVersion = StaticCodecVersion<0, 1, 1>;
 
 /// Codec providing compression using EBCC.
 ///

--- a/codecs/ebcc/src/lib.rs
+++ b/codecs/ebcc/src/lib.rs
@@ -22,7 +22,7 @@
 #[cfg(test)]
 use ::serde_json as _;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, num::NonZeroUsize};
 
 use ndarray::{Array, Array1, ArrayBase, ArrayViewMut, Axis, Data, DataMut, Dimension, IxDyn};
 use num_traits::Float;
@@ -54,9 +54,25 @@ pub struct EbccCodec {
     /// JPEG2000 positive base compression ratio
     #[serde(default = "default_base_cr")]
     pub base_cr: Positive<f32>,
+    /// Optional EBCC-internal chunk shape.
+    #[serde(default)]
+    pub chunk_shape: EbccChunkShape,
     /// The codec's encoding format version. Do not provide this parameter explicitly.
     #[serde(default, rename = "_version")]
     pub version: EbccCodecVersion,
+}
+
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+/// Chunk shape that EBCC uses to handle large data.
+pub enum EbccChunkShape {
+    /// EBCC chooses an appropriate chunk shape automatically.
+    #[serde(rename = "auto")]
+    #[default]
+    Auto,
+    /// EBCC uses the provided explicit chunk shape.
+    #[serde(untagged)]
+    Explicit([NonZeroUsize; 3]),
 }
 
 const fn default_base_cr() -> Positive<f32> {
@@ -91,7 +107,13 @@ impl Codec for EbccCodec {
     fn encode(&self, data: AnyCowArray) -> Result<AnyArray, Self::Error> {
         match data {
             AnyCowArray::F32(data) => Ok(AnyArray::U8(
-                Array1::from(compress(data, self.residual, self.base_cr)?).into_dyn(),
+                Array1::from(compress(
+                    data,
+                    self.residual,
+                    self.base_cr,
+                    self.chunk_shape,
+                )?)
+                .into_dyn(),
             )),
             encoded => Err(EbccCodecError::UnsupportedDtype(encoded.dtype())),
         }
@@ -300,7 +322,7 @@ pub struct EbccSliceError(postcard::Error);
 pub struct EbccCodingError(ebcc::EBCCError);
 
 /// Compress the `data` array using EBCC with the provided `residual` and
-/// `base_cr`.
+/// `base_cr`. The `data` is internally chunked using the `chunk_shape`.
 ///
 /// # Errors
 ///
@@ -315,6 +337,7 @@ pub fn compress<S: Data<Elem = f32>, D: Dimension>(
     data: ArrayBase<S, D>,
     residual: EbccResidualType,
     base_cr: Positive<f32>,
+    chunk_shape: EbccChunkShape,
 ) -> Result<Vec<u8>, EbccCodecError> {
     let mut encoded = postcard::to_extend(
         &CompressionHeader {
@@ -378,7 +401,12 @@ pub fn compress<S: Data<Elem = f32>, D: Dimension>(
                     }
                 },
             },
-            None,
+            match chunk_shape {
+                EbccChunkShape::Auto => ebcc::EBCCCompatChunkShape::Auto,
+                EbccChunkShape::Explicit(chunk_shape) => {
+                    ebcc::EBCCCompatChunkShape::Explicit(chunk_shape)
+                }
+            },
         )
         .map_err(|err| EbccCodecError::EbccEncodeFailed {
             source: EbccCodingError(err),
@@ -548,6 +576,7 @@ mod tests {
             residual: EbccResidualType::Jpeg2000Only,
             base_cr: Positive(10.0),
             version: StaticCodecVersion,
+            chunk_shape: EbccChunkShape::Auto,
         };
 
         let data = Array1::<i32>::zeros(100);
@@ -562,6 +591,7 @@ mod tests {
             residual: EbccResidualType::Jpeg2000Only,
             base_cr: Positive(10.0),
             version: StaticCodecVersion,
+            chunk_shape: EbccChunkShape::Auto,
         };
 
         // Test dimensions too small (32 < 32x32 requirement)
@@ -619,6 +649,7 @@ mod tests {
             },
             base_cr: Positive(20.0),
             version: StaticCodecVersion,
+            chunk_shape: EbccChunkShape::Auto,
         };
 
         let encoded = codec.encode(AnyArray::F32(data.clone().into_dyn()).into_cow())?;
@@ -682,6 +713,7 @@ mod tests {
             },
             base_cr: Positive(20.0),
             version: StaticCodecVersion,
+            chunk_shape: EbccChunkShape::Auto,
         };
 
         let encoded = codec.encode(AnyArray::F32(data.clone().into_dyn()).into_cow())?;

--- a/codecs/ebcc/src/lib.rs
+++ b/codecs/ebcc/src/lib.rs
@@ -378,7 +378,7 @@ pub fn compress<S: Data<Elem = f32>, D: Dimension>(
                     }
                 },
             },
-            [0; ebcc::EBCC_NDIMS],
+            None,
         )
         .map_err(|err| EbccCodecError::EbccEncodeFailed {
             source: EbccCodingError(err),

--- a/codecs/ebcc/src/lib.rs
+++ b/codecs/ebcc/src/lib.rs
@@ -364,7 +364,7 @@ pub fn compress<S: Data<Elem = f32>, D: Dimension>(
         //  must be of size 1
         let slice = slice.into_shape_with_order((depth, height, width)).unwrap();
 
-        let encoded_slice = ebcc::ebcc_encode(
+        let encoded_slice = ebcc::ebcc_encode_chunking_compat(
             slice,
             &ebcc::EBCCConfig {
                 base_cr: base_cr.0,
@@ -378,6 +378,7 @@ pub fn compress<S: Data<Elem = f32>, D: Dimension>(
                     }
                 },
             },
+            [0; ebcc::EBCC_NDIMS],
         )
         .map_err(|err| EbccCodecError::EbccEncodeFailed {
             source: EbccCodingError(err),
@@ -508,7 +509,7 @@ fn decompress_into_typed(
         //  three must be of size 1
         let slice = slice.into_shape_with_order((depth, height, width)).unwrap();
 
-        ebcc::ebcc_decode_into(&encoded_slice, slice).map_err(|err| {
+        ebcc::ebcc_decode_chunking_into(&encoded_slice, slice).map_err(|err| {
             EbccCodecError::EbccDecodeFailed {
                 source: EbccCodingError(err),
             }
@@ -601,6 +602,69 @@ mod tests {
         let height = 721; // Quarter degree resolution
         let width = 1440;
         let frames = 1;
+
+        #[expect(clippy::suboptimal_flops, clippy::cast_precision_loss)]
+        let data = Array::from_shape_fn((frames, height, width), |(_k, i, j)| {
+            let lat = -90.0 + (i as f32 / height as f32) * 180.0;
+            let lon = -180.0 + (j as f32 / width as f32) * 360.0;
+            #[allow(clippy::let_and_return)]
+            let temp = 273.15 + 30.0 * (1.0 - lat.abs() / 90.0) + 5.0 * (lon / 180.0).sin();
+            temp
+        });
+
+        let codec_error = 0.1;
+        let codec = EbccCodec {
+            residual: EbccResidualType::AbsoluteError {
+                error: Positive(codec_error),
+            },
+            base_cr: Positive(20.0),
+            version: StaticCodecVersion,
+        };
+
+        let encoded = codec.encode(AnyArray::F32(data.clone().into_dyn()).into_cow())?;
+        let decoded = codec.decode(encoded.cow())?;
+
+        let AnyArray::U8(encoded) = encoded else {
+            return Err(EbccCodecError::EncodedDataNotBytes {
+                dtype: encoded.dtype(),
+            });
+        };
+
+        let AnyArray::F32(decoded) = decoded else {
+            return Err(EbccCodecError::UnsupportedDtype(decoded.dtype()));
+        };
+
+        // Check compression ratio
+        let original_size = data.len() * std::mem::size_of::<f32>();
+        #[allow(clippy::cast_precision_loss)]
+        let compression_ratio = original_size as f64 / encoded.len() as f64;
+
+        assert!(
+            compression_ratio > 5.0,
+            "Compression ratio {compression_ratio} should be at least 5:1",
+        );
+
+        // Check error bound is respected
+        let max_error = data
+            .iter()
+            .zip(decoded.iter())
+            .map(|(&orig, &decomp)| (orig - decomp).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_error <= (codec_error + 1e-6),
+            "Max error {max_error} exceeds error bound {codec_error}",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_huge_array() -> Result<(), EbccCodecError> {
+        // Test with a huge array that would require chunking
+        let height = 721 * 2; // Quarter degree resolution
+        let width = 1440 * 2;
+        let frames = 2;
 
         #[expect(clippy::suboptimal_flops, clippy::cast_precision_loss)]
         let data = Array::from_shape_fn((frames, height, width), |(_k, i, j)| {

--- a/codecs/ebcc/tests/config.rs
+++ b/codecs/ebcc/tests/config.rs
@@ -1,10 +1,12 @@
 #![expect(missing_docs)]
 #![expect(clippy::unwrap_used)]
 
+use std::num::NonZeroUsize;
+
 use ::{ebcc as _, ndarray as _, num_traits as _, postcard as _, schemars as _, thiserror as _};
 
 use numcodecs::StaticCodec;
-use numcodecs_ebcc::{EbccCodec, EbccResidualType};
+use numcodecs_ebcc::{EbccChunkShape, EbccCodec, EbccResidualType};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -37,6 +39,7 @@ fn jpeg2000_only() {
 
     assert_eq!(codec.base_cr, 10.0);
     assert_eq!(codec.residual, EbccResidualType::Jpeg2000Only);
+    assert!(matches!(codec.chunk_shape, EbccChunkShape::Auto));
 }
 
 #[test]
@@ -78,6 +81,49 @@ fn invalid_residual() {
         Deserialize::deserialize(json!({
             "base_cr": 10.0,
             "residual": "invalid",
+        }))
+        .unwrap(),
+    );
+}
+
+#[test]
+fn auto_chunk_shape() {
+    let codec = EbccCodec::from_config(
+        Deserialize::deserialize(json!({
+            "base_cr": 10.0,
+            "residual": "jpeg2000-only",
+            "chunk_shape": "auto",
+        }))
+        .unwrap(),
+    );
+
+    assert!(matches!(codec.chunk_shape, EbccChunkShape::Auto));
+}
+
+#[test]
+fn explicit_chunk_shape() {
+    let codec = EbccCodec::from_config(
+        Deserialize::deserialize(json!({
+            "base_cr": 10.0,
+            "residual": "jpeg2000-only",
+            "chunk_shape": [32, 32, 32],
+        }))
+        .unwrap(),
+    );
+
+    assert!(
+        matches!(codec.chunk_shape, EbccChunkShape::Explicit(chunk_shape) if chunk_shape == [NonZeroUsize::new(32).unwrap(); 3])
+    );
+}
+
+#[test]
+#[should_panic(expected = "data did not match any variant")]
+fn invalid_explicit_chunk_shape() {
+    let _ = EbccCodec::from_config(
+        Deserialize::deserialize(json!({
+            "base_cr": 10.0,
+            "residual": "jpeg2000-only",
+            "chunk_shape": [32, 0, 32],
         }))
         .unwrap(),
     );

--- a/codecs/ebcc/tests/schema.json
+++ b/codecs/ebcc/tests/schema.json
@@ -88,7 +88,7 @@
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
       "description": "The codec's encoding format version. Do not provide this parameter explicitly.",
-      "default": "0.1.0"
+      "default": "0.1.1"
     }
   },
   "title": "EbccCodec",

--- a/codecs/ebcc/tests/schema.json
+++ b/codecs/ebcc/tests/schema.json
@@ -62,6 +62,28 @@
       "description": "JPEG2000 positive base compression ratio",
       "default": 100.0
     },
+    "chunk_shape": {
+      "anyOf": [
+        {
+          "type": "string",
+          "const": "auto",
+          "description": "EBCC chooses an appropriate chunk shape automatically."
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "description": "EBCC uses the provided explicit chunk shape."
+        }
+      ],
+      "description": "Optional EBCC-internal chunk shape.",
+      "default": "auto"
+    },
     "_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",

--- a/py/numcodecs-wasm-template/pyproject.toml
+++ b/py/numcodecs-wasm-template/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 
 dependencies = [
-    "numcodecs-wasm~=0.2.4", # wasi 0.2.6
+    "numcodecs-wasm~=0.2.2", # wasi 0.2.6
 ]
 
 [project.entry-points."numcodecs.codecs"]


### PR DESCRIPTION
- [x] temporarily lower the numcodecs-wasm bound to support the older version pinned in the benchmark
- [x] bring back the latest numcodecs-wasm bound