### PR TITLE
Implement numcodecs-wasm guest-side support for the codec registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
         lock: ["Cargo.lock", "Cargo.lock.min"]
         codec: ${{ fromJSON(needs.codecs-ls.outputs.codecs) }}
     runs-on: ${{ matrix.os }}
-    needs: ["lock", "codecs-ls"]
+    needs: ["lock", "codecs-ls", "numcodecs-wasm"]
 
     steps:
       - name: Checkout the Repository
@@ -351,13 +351,22 @@ jobs:
         run: mv ${{ matrix.lock }} Cargo.lock
         if: ${{ matrix.lock != 'Cargo.lock' }}
 
+      - name: Download numcodecs-wasm
+        uses: actions/download-artifact@v8
+        with:
+          pattern: numcodecs-wasm
+          path: py/numcodecs-wasm-materialize
+
       - name: Build the ${{ matrix.codec }} WASM codec
         run: |
           cd py/numcodecs-wasm-materialize
           rm .python-version
           uv python install ${{ matrix.python }}
           uv sync && uv pip install .
-          uv run python3 -m numcodecs_wasm_materialize "^${{ matrix.codec }}$" --local
+          uv run python3 -m numcodecs_wasm_materialize \
+            "^${{ matrix.codec }}$" \
+            --local \
+            --numcodecs-wasm-wheel numcodecs_wasm-*.whl
 
       - name: Upload the ${{ matrix.codec }} WASM codec
         if: ${{ matrix.lock == 'Cargo.lock' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,7 @@ jobs:
           ls dist/*.whl | xargs -n 1 uv pip install
 
       - name: Test the WASM codecs (PyPi numcodecs-wasm)
+        if: always()
         run: |
           uv run python -c "from pathlib import Path; errors = []; [exec('try:\n    import ' + p.name.split('-')[0] + ' as c; print(c)\nexcept ImportError as err:\n    errors.append(err)') for p in sorted(Path('dist').glob('*.whl'))]; exec('if len(errors) > 0:\n    raise Exception(errors)')"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
           rm .python-version
           uv python install ${{ matrix.python }}
           uv sync && uv pip install .
-          uv run python3 -m numcodecs_wasm_materialize \
+          uv run python -m numcodecs_wasm_materialize \
             "^${{ matrix.codec }}$" \
             --local \
             --numcodecs-wasm-wheel numcodecs_wasm-*.whl
@@ -479,11 +479,11 @@ jobs:
         run: |
           uv venv
           uv python install ${{ matrix.python }}
-          uv pip install dist/*.whl
+          ls dist/*.whl | xargs -n 1 uv pip install
 
       - name: Test the WASM codecs (PyPi numcodecs-wasm)
         run: |
-          uv run python3 -c "import importlib; from pathlib import Path; [print(importlib.import_module(p.name.split('-')[0])) for p in sorted(Path('dist').glob('*.whl'))]"
+          uv run python -c "from pathlib import Path; errors = []; [exec('try:\n    import ' + p.name.split('-')[0] + ' as c; print(c)\nexcept ImportError as err:\n    errors.append(err)') for p in sorted(Path('dist').glob('*.whl'))]; exec('if len(errors) > 0:\n    raise Exception(errors)')"
 
       - name: Download numcodecs-wasm
         if: always()
@@ -496,11 +496,12 @@ jobs:
         if: always()
         run: |
           uv pip install dist/numcodecs_wasm-*.whl
+          ls dist/*.whl | xargs -n 1 uv pip install
 
       - name: Test importing the WASM codecs (local numcodecs-wasm)
         if: always()
         run: |
-          uv run python3 -c "import importlib; from pathlib import Path; [print(importlib.import_module(p.name.split('-')[0])) for p in sorted(Path('dist').glob('*.whl'))]"
+          uv run python -c "from pathlib import Path; errors = []; [exec('try:\n    import ' + p.name.split('-')[0] + ' as c; print(c)\nexcept ImportError as err:\n    errors.append(err)') for p in sorted(Path('dist').glob('*.whl'))]; exec('if len(errors) > 0:\n    raise Exception(errors)')"
 
   wasm-codecs-test-pyemscripten:
     name: Test the WASM codecs on PyEmscripten
@@ -541,9 +542,9 @@ jobs:
           pyodide venv .venv-pyodide
           source .venv-pyodide/bin/activate
           python -m pip install ${{ matrix.python.numpy }}
-          python -m pip install dist/*.whl
+          ls dist/*.whl | xargs -n 1 python -m pip install
 
       - name: Test importing the WASM codecs (local numcodecs-wasm)
         run: |
           source .venv-pyodide/bin/activate
-          python -c "import importlib; from pathlib import Path; [print(importlib.import_module(p.name.split('-')[0])) for p in sorted(Path('dist').glob('*.whl'))]"
+          python -c "from pathlib import Path; errors = []; [exec('try:\n    import ' + p.name.split('-')[0] + ' as c; print(c)\nexcept ImportError as err:\n    errors.append(err)') for p in sorted(Path('dist').glob('*.whl'))]; exec('if len(errors) > 0:\n    raise Exception(errors)')"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ rust-version = "1.87"
 
 [workspace.dependencies]
 # workspace-internal numcodecs crates
-numcodecs = { version = "0.3.1", path = "crates/numcodecs", default-features = false }
+numcodecs = { version = "0.3.2", path = "crates/numcodecs", default-features = false }
 numcodecs-python = { version = "0.7.1", path = "crates/numcodecs-python", default-features = false }
 numcodecs-registry = { version = "0.1", path = "crates/numcodecs-registry", default-features = false }
 numcodecs-wasm-builder = { version = "0.2", path = "crates/numcodecs-wasm-builder", default-features = false }
-numcodecs-wasm-guest = { version = "0.3", path = "crates/numcodecs-wasm-guest", default-features = false }
+numcodecs-wasm-guest = { version = "0.3.1", path = "crates/numcodecs-wasm-guest", default-features = false }
 numcodecs-wasm-host = { version = "0.2.1", path = "crates/numcodecs-wasm-host", default-features = false }
 numcodecs-wasm-host-reproducible = { version = "0.2.3", path = "crates/numcodecs-wasm-host-reproducible", default-features = false }
 numcodecs-wasm-logging = { version = "0.2", path = "crates/numcodecs-wasm-logging", default-features = false }

--- a/codecs/onion/Cargo.toml
+++ b/codecs/onion/Cargo.toml
@@ -25,4 +25,5 @@ thiserror = { workspace = true }
 workspace = true
 
 [package.metadata.numcodecs-wasm]
-version = "0.2.4"  # wasi 0.2.6
+version = "0.2.5"  # wasi 0.2.6
+wasm-features = ["registry"]

--- a/codecs/onion/src/lib.rs
+++ b/codecs/onion/src/lib.rs
@@ -88,8 +88,3 @@ impl StaticCodec for OnionCodec {
 pub struct OnionCodecError {
     error: ErasedError,
 }
-
-// FIXME: provide global registry elsewhere
-numcodecs_registry::export_global! {
-    static REGISTRY: numcodecs_registry::EmptyRegistry = numcodecs_registry::EmptyRegistry;
-}

--- a/codecs/onion/tests/schema.rs
+++ b/codecs/onion/tests/schema.rs
@@ -1,6 +1,6 @@
 #![expect(missing_docs)]
 
-use ::{numcodecs_registry as _, schemars as _, serde as _, thiserror as _};
+use ::{schemars as _, serde as _, thiserror as _};
 
 use numcodecs::{DynCodecType, StaticCodecType};
 use numcodecs_onion::OnionCodec;
@@ -17,4 +17,8 @@ fn schema() {
     if schema != include_str!("schema.json") {
         panic!("Onion schema has changed\n===\n{schema}\n===");
     }
+}
+
+numcodecs_registry::export_global! {
+    static REGISTRY: numcodecs_registry::EmptyRegistry = numcodecs_registry::EmptyRegistry;
 }

--- a/crates/numcodecs-wasm-builder/src/main.rs
+++ b/crates/numcodecs-wasm-builder/src/main.rs
@@ -45,6 +45,10 @@ struct Args {
     /// Enable verbose logging while compiling the crate
     #[arg(long)]
     verbose: bool,
+
+    /// Enable experimental features for the WASM guest
+    #[arg(long)]
+    wasm_features: Vec<String>,
 }
 
 fn main() -> io::Result<()> {
@@ -68,6 +72,7 @@ fn main() -> io::Result<()> {
         &args.version,
         &args.codec,
         args.local,
+        &args.wasm_features,
     )?;
     copy_buildenv_to_crate(&crate_dir)?;
 
@@ -95,6 +100,7 @@ fn create_codec_wasm_component_crate(
     version: &Version,
     codec: &str,
     local: bool,
+    wasm_features: &[String],
 ) -> io::Result<PathBuf> {
     let crate_dir = scratch_dir.join(format!("{crate_}-wasm-{version}"));
     eprintln!("crate_dir={}", crate_dir.display());
@@ -138,7 +144,7 @@ edition = "2024"
 
 [dependencies]
 numcodecs-wasm-logging = {{ version = "0.2",{numcodecs_wasm_logging_path} default-features = false }}
-numcodecs-wasm-guest = {{ version = "0.3",{numcodecs_wasm_guest_path} default-features = false }}
+numcodecs-wasm-guest = {{ version = "0.3",{numcodecs_wasm_guest_path} default-features = false, features = {wasm_features:?} }}
 numcodecs-my-codec = {{ package = "{crate_}", version = "{version}",{numcodecs_my_codec_path} default-features = false }}
     "#
         ),

--- a/crates/numcodecs-wasm-guest/Cargo.toml
+++ b/crates/numcodecs-wasm-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-wasm-guest"
-version = "0.3.0"
+version = "0.3.1"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/crates/numcodecs-wasm-guest/Cargo.toml
+++ b/crates/numcodecs-wasm-guest/Cargo.toml
@@ -19,8 +19,10 @@ wit-bindgen = { workspace = true, features = ["macros", "realloc"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 format_serde_error = { workspace = true, features = ["serde_json"] }
 ndarray = { workspace = true, features = ["std"] }
+numcodecs-registry = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
+serde-transcode = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 

--- a/crates/numcodecs-wasm-guest/Cargo.toml
+++ b/crates/numcodecs-wasm-guest/Cargo.toml
@@ -16,13 +16,16 @@ keywords = ["numcodecs", "compression", "encoding", "wasm-component", "wasm-bind
 numcodecs = { workspace = true }
 wit-bindgen = { workspace = true, features = ["macros", "realloc"] }
 
+[features]
+registry = ["dep:numcodecs-registry", "dep:serde-transcode"]
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 format_serde_error = { workspace = true, features = ["serde_json"] }
 ndarray = { workspace = true, features = ["std"] }
-numcodecs-registry = { workspace = true }
+numcodecs-registry = { workspace = true, optional = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-serde-transcode = { workspace = true }
+serde-transcode = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 

--- a/crates/numcodecs-wasm-guest/src/convert.rs
+++ b/crates/numcodecs-wasm-guest/src/convert.rs
@@ -9,7 +9,7 @@ use crate::wit;
 pub fn from_wit_any_array(
     array: wit::types::AnyArray,
 ) -> Result<AnyArray, AnyArrayConversionError> {
-    let shape = u32_as_usize_vec(array.shape);
+    let shape = from_wit_usize_vec(array.shape);
 
     let array = match array.data {
         wit::types::AnyArrayData::U8(data) => AnyArray::U8(Array::from_shape_vec(shape, data)?),
@@ -28,7 +28,7 @@ pub fn from_wit_any_array(
 }
 
 pub fn zeros_from_wit_any_array_prototype(prototype: wit::types::AnyArrayPrototype) -> AnyArray {
-    let shape = u32_as_usize_vec(prototype.shape);
+    let shape = from_wit_usize_vec(prototype.shape);
 
     match prototype.dtype {
         wit::types::AnyArrayDtype::U8 => AnyArray::U8(Array::zeros(shape)),
@@ -55,7 +55,7 @@ pub fn into_wit_any_array(
         }
     }
 
-    let shape = usize_as_u32_slice(array.shape());
+    let shape = into_wit_usize_vec(array.shape());
 
     let data = match array {
         AnyArray::U8(array) => wit::types::AnyArrayData::U8(array_into_standard_layout_vec(array)),
@@ -94,6 +94,7 @@ pub fn into_wit_any_array(
     Ok(wit::types::AnyArray { data, shape })
 }
 
+#[cfg(feature = "registry")]
 pub fn into_wit_any_array_dtype(
     dtype: AnyArrayDType,
 ) -> Result<wit::types::AnyArrayDtype, AnyArrayConversionError> {
@@ -150,11 +151,11 @@ pub fn into_wit_error<T: Error>(err: T) -> wit::types::Error {
 
 #[expect(clippy::cast_possible_truncation)]
 #[must_use]
-pub(crate) fn usize_as_u32_slice(slice: &[usize]) -> Vec<u32> {
-    slice.iter().map(|x| *x as u32).collect()
+pub(crate) fn into_wit_usize_vec(slice: &[usize]) -> Vec<wit::types::Usize> {
+    slice.iter().map(|x| *x as wit::types::Usize).collect()
 }
 
 #[must_use]
-pub(crate) fn u32_as_usize_vec(vec: Vec<u32>) -> Vec<usize> {
+pub(crate) fn from_wit_usize_vec(vec: Vec<wit::types::Usize>) -> Vec<usize> {
     vec.into_iter().map(|x| x as usize).collect()
 }

--- a/crates/numcodecs-wasm-guest/src/convert.rs
+++ b/crates/numcodecs-wasm-guest/src/convert.rs
@@ -6,43 +6,47 @@ use thiserror::Error;
 
 use crate::wit;
 
-pub fn from_wit_any_array(array: wit::AnyArray) -> Result<AnyArray, AnyArrayConversionError> {
+pub fn from_wit_any_array(
+    array: wit::types::AnyArray,
+) -> Result<AnyArray, AnyArrayConversionError> {
     let shape = u32_as_usize_vec(array.shape);
 
     let array = match array.data {
-        wit::AnyArrayData::U8(data) => AnyArray::U8(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::U16(data) => AnyArray::U16(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::U32(data) => AnyArray::U32(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::U64(data) => AnyArray::U64(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::I8(data) => AnyArray::I8(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::I16(data) => AnyArray::I16(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::I32(data) => AnyArray::I32(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::I64(data) => AnyArray::I64(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::F32(data) => AnyArray::F32(Array::from_shape_vec(shape, data)?),
-        wit::AnyArrayData::F64(data) => AnyArray::F64(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::U8(data) => AnyArray::U8(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::U16(data) => AnyArray::U16(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::U32(data) => AnyArray::U32(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::U64(data) => AnyArray::U64(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::I8(data) => AnyArray::I8(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::I16(data) => AnyArray::I16(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::I32(data) => AnyArray::I32(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::I64(data) => AnyArray::I64(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::F32(data) => AnyArray::F32(Array::from_shape_vec(shape, data)?),
+        wit::types::AnyArrayData::F64(data) => AnyArray::F64(Array::from_shape_vec(shape, data)?),
     };
 
     Ok(array)
 }
 
-pub fn zeros_from_wit_any_array_prototype(prototype: wit::AnyArrayPrototype) -> AnyArray {
+pub fn zeros_from_wit_any_array_prototype(prototype: wit::types::AnyArrayPrototype) -> AnyArray {
     let shape = u32_as_usize_vec(prototype.shape);
 
     match prototype.dtype {
-        wit::AnyArrayDtype::U8 => AnyArray::U8(Array::zeros(shape)),
-        wit::AnyArrayDtype::U16 => AnyArray::U16(Array::zeros(shape)),
-        wit::AnyArrayDtype::U32 => AnyArray::U32(Array::zeros(shape)),
-        wit::AnyArrayDtype::U64 => AnyArray::U64(Array::zeros(shape)),
-        wit::AnyArrayDtype::I8 => AnyArray::I8(Array::zeros(shape)),
-        wit::AnyArrayDtype::I16 => AnyArray::I16(Array::zeros(shape)),
-        wit::AnyArrayDtype::I32 => AnyArray::I32(Array::zeros(shape)),
-        wit::AnyArrayDtype::I64 => AnyArray::I64(Array::zeros(shape)),
-        wit::AnyArrayDtype::F32 => AnyArray::F32(Array::zeros(shape)),
-        wit::AnyArrayDtype::F64 => AnyArray::F64(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::U8 => AnyArray::U8(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::U16 => AnyArray::U16(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::U32 => AnyArray::U32(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::U64 => AnyArray::U64(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::I8 => AnyArray::I8(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::I16 => AnyArray::I16(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::I32 => AnyArray::I32(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::I64 => AnyArray::I64(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::F32 => AnyArray::F32(Array::zeros(shape)),
+        wit::types::AnyArrayDtype::F64 => AnyArray::F64(Array::zeros(shape)),
     }
 }
 
-pub fn into_wit_any_array(array: AnyArray) -> Result<wit::AnyArray, AnyArrayConversionError> {
+pub fn into_wit_any_array(
+    array: AnyArray,
+) -> Result<wit::types::AnyArray, AnyArrayConversionError> {
     fn array_into_standard_layout_vec<T>(array: ArrayD<T>) -> Vec<T> {
         if array.is_standard_layout() {
             array.into_raw_vec_and_offset().0
@@ -54,16 +58,32 @@ pub fn into_wit_any_array(array: AnyArray) -> Result<wit::AnyArray, AnyArrayConv
     let shape = usize_as_u32_slice(array.shape());
 
     let data = match array {
-        AnyArray::U8(array) => wit::AnyArrayData::U8(array_into_standard_layout_vec(array)),
-        AnyArray::U16(array) => wit::AnyArrayData::U16(array_into_standard_layout_vec(array)),
-        AnyArray::U32(array) => wit::AnyArrayData::U32(array_into_standard_layout_vec(array)),
-        AnyArray::U64(array) => wit::AnyArrayData::U64(array_into_standard_layout_vec(array)),
-        AnyArray::I8(array) => wit::AnyArrayData::I8(array_into_standard_layout_vec(array)),
-        AnyArray::I16(array) => wit::AnyArrayData::I16(array_into_standard_layout_vec(array)),
-        AnyArray::I32(array) => wit::AnyArrayData::I32(array_into_standard_layout_vec(array)),
-        AnyArray::I64(array) => wit::AnyArrayData::I64(array_into_standard_layout_vec(array)),
-        AnyArray::F32(array) => wit::AnyArrayData::F32(array_into_standard_layout_vec(array)),
-        AnyArray::F64(array) => wit::AnyArrayData::F64(array_into_standard_layout_vec(array)),
+        AnyArray::U8(array) => wit::types::AnyArrayData::U8(array_into_standard_layout_vec(array)),
+        AnyArray::U16(array) => {
+            wit::types::AnyArrayData::U16(array_into_standard_layout_vec(array))
+        }
+        AnyArray::U32(array) => {
+            wit::types::AnyArrayData::U32(array_into_standard_layout_vec(array))
+        }
+        AnyArray::U64(array) => {
+            wit::types::AnyArrayData::U64(array_into_standard_layout_vec(array))
+        }
+        AnyArray::I8(array) => wit::types::AnyArrayData::I8(array_into_standard_layout_vec(array)),
+        AnyArray::I16(array) => {
+            wit::types::AnyArrayData::I16(array_into_standard_layout_vec(array))
+        }
+        AnyArray::I32(array) => {
+            wit::types::AnyArrayData::I32(array_into_standard_layout_vec(array))
+        }
+        AnyArray::I64(array) => {
+            wit::types::AnyArrayData::I64(array_into_standard_layout_vec(array))
+        }
+        AnyArray::F32(array) => {
+            wit::types::AnyArrayData::F32(array_into_standard_layout_vec(array))
+        }
+        AnyArray::F64(array) => {
+            wit::types::AnyArrayData::F64(array_into_standard_layout_vec(array))
+        }
         array => {
             return Err(AnyArrayConversionError::UnsupportedDtype {
                 dtype: array.dtype(),
@@ -71,7 +91,29 @@ pub fn into_wit_any_array(array: AnyArray) -> Result<wit::AnyArray, AnyArrayConv
         }
     };
 
-    Ok(wit::AnyArray { data, shape })
+    Ok(wit::types::AnyArray { data, shape })
+}
+
+pub fn into_wit_any_array_dtype(
+    dtype: AnyArrayDType,
+) -> Result<wit::types::AnyArrayDtype, AnyArrayConversionError> {
+    let dtype = match dtype {
+        AnyArrayDType::U8 => wit::types::AnyArrayDtype::U8,
+        AnyArrayDType::U16 => wit::types::AnyArrayDtype::U16,
+        AnyArrayDType::U32 => wit::types::AnyArrayDtype::U32,
+        AnyArrayDType::U64 => wit::types::AnyArrayDtype::U64,
+        AnyArrayDType::I8 => wit::types::AnyArrayDtype::I8,
+        AnyArrayDType::I16 => wit::types::AnyArrayDtype::I16,
+        AnyArrayDType::I32 => wit::types::AnyArrayDtype::I32,
+        AnyArrayDType::I64 => wit::types::AnyArrayDtype::I64,
+        AnyArrayDType::F32 => wit::types::AnyArrayDtype::F32,
+        AnyArrayDType::F64 => wit::types::AnyArrayDtype::F64,
+        dtype => {
+            return Err(AnyArrayConversionError::UnsupportedDtype { dtype });
+        }
+    };
+
+    Ok(dtype)
 }
 
 #[derive(Debug, Error)]
@@ -86,10 +128,10 @@ pub enum AnyArrayConversionError {
 }
 
 #[must_use]
-pub fn into_wit_error<T: Error>(err: T) -> wit::Error {
+pub fn into_wit_error<T: Error>(err: T) -> wit::types::Error {
     let mut source: Option<&dyn Error> = err.source();
 
-    let mut error = wit::Error {
+    let mut error = wit::types::Error {
         message: format!("{err}"),
         chain: if source.is_some() {
             Vec::with_capacity(4)
@@ -108,11 +150,11 @@ pub fn into_wit_error<T: Error>(err: T) -> wit::Error {
 
 #[expect(clippy::cast_possible_truncation)]
 #[must_use]
-fn usize_as_u32_slice(slice: &[usize]) -> Vec<u32> {
+pub(crate) fn usize_as_u32_slice(slice: &[usize]) -> Vec<u32> {
     slice.iter().map(|x| *x as u32).collect()
 }
 
 #[must_use]
-fn u32_as_usize_vec(vec: Vec<u32>) -> Vec<usize> {
+pub(crate) fn u32_as_usize_vec(vec: Vec<u32>) -> Vec<usize> {
     vec.into_iter().map(|x| x as usize).collect()
 }

--- a/crates/numcodecs-wasm-guest/src/convert.rs
+++ b/crates/numcodecs-wasm-guest/src/convert.rs
@@ -95,7 +95,7 @@ pub fn into_wit_any_array(
 }
 
 #[cfg(feature = "registry")]
-pub fn into_wit_any_array_dtype(
+pub const fn into_wit_any_array_dtype(
     dtype: AnyArrayDType,
 ) -> Result<wit::types::AnyArrayDtype, AnyArrayConversionError> {
     let dtype = match dtype {

--- a/crates/numcodecs-wasm-guest/src/convert.rs
+++ b/crates/numcodecs-wasm-guest/src/convert.rs
@@ -151,11 +151,11 @@ pub fn into_wit_error<T: Error>(err: T) -> wit::types::Error {
 
 #[expect(clippy::cast_possible_truncation)]
 #[must_use]
-pub(crate) fn into_wit_usize_vec(slice: &[usize]) -> Vec<wit::types::Usize> {
+pub fn into_wit_usize_vec(slice: &[usize]) -> Vec<wit::types::Usize> {
     slice.iter().map(|x| *x as wit::types::Usize).collect()
 }
 
 #[must_use]
-pub(crate) fn from_wit_usize_vec(vec: Vec<wit::types::Usize>) -> Vec<usize> {
+pub fn from_wit_usize_vec(vec: Vec<wit::types::Usize>) -> Vec<usize> {
     vec.into_iter().map(|x| x as usize).collect()
 }

--- a/crates/numcodecs-wasm-guest/src/external.rs
+++ b/crates/numcodecs-wasm-guest/src/external.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use numcodecs::{
-    self, AnyArray, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, DynCodec, DynCodecType,
+    AnyArray, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, DynCodec, DynCodecType,
     ErasedDynCodec,
 };
-use numcodecs_registry::{self, Registry, export_global};
+use numcodecs_registry::Registry;
 use schemars::Schema;
-use serde::{self, Deserializer, Serializer};
+use serde::{Deserializer, Serializer};
 use serde_transcode::transcode;
 
 use crate::{convert, wit};
@@ -200,4 +200,6 @@ impl Registry for ExternalRegistry {
     }
 }
 
-export_global! { registry: ExternalRegistry = ExternalRegistry }
+numcodecs_registry::export_global! {
+    static REGISTRY: ExternalRegistry = ExternalRegistry;
+}

--- a/crates/numcodecs-wasm-guest/src/external.rs
+++ b/crates/numcodecs-wasm-guest/src/external.rs
@@ -1,0 +1,203 @@
+use std::sync::Arc;
+
+use numcodecs::{
+    self, AnyArray, AnyArrayView, AnyArrayViewMut, AnyCowArray, Codec, DynCodec, DynCodecType,
+    ErasedDynCodec,
+};
+use numcodecs_registry::{self, Registry, export_global};
+use schemars::Schema;
+use serde::{self, Deserializer, Serializer};
+use serde_transcode::transcode;
+
+use crate::{convert, wit};
+
+pub struct ExternalCodec {
+    codec: wit::registry::ExternalCodec,
+    ty: ExternalCodecType,
+}
+
+impl Clone for ExternalCodec {
+    fn clone(&self) -> Self {
+        Self {
+            codec: self.codec.clone(),
+            ty: ExternalCodecType {
+                ty: self.ty.ty.clone(),
+                codec_id: self.ty.codec_id.clone(),
+                schema: self.ty.schema.clone(),
+            },
+        }
+    }
+}
+
+impl Codec for ExternalCodec {
+    type Error = ExternalError;
+
+    fn encode(&self, data: AnyCowArray) -> Result<AnyArray, Self::Error> {
+        match self.codec.encode(
+            &convert::into_wit_any_array(data.into_owned()).map_err(ExternalError::from_error)?,
+        ) {
+            Ok(encoded) => convert::from_wit_any_array(encoded).map_err(ExternalError::from_error),
+            Err(err) => Err(ExternalError::new(err)),
+        }
+    }
+
+    fn decode(&self, encoded: AnyCowArray) -> Result<AnyArray, Self::Error> {
+        match self.codec.decode(
+            &convert::into_wit_any_array(encoded.into_owned())
+                .map_err(ExternalError::from_error)?,
+        ) {
+            Ok(decoded) => convert::from_wit_any_array(decoded).map_err(ExternalError::from_error),
+            Err(err) => Err(ExternalError::new(err)),
+        }
+    }
+
+    fn decode_into(
+        &self,
+        encoded: AnyArrayView,
+        mut decoded: AnyArrayViewMut,
+    ) -> Result<(), Self::Error> {
+        match self.codec.decode_into(
+            &convert::into_wit_any_array(encoded.into_owned())
+                .map_err(ExternalError::from_error)?,
+            &wit::types::AnyArrayPrototype {
+                dtype: convert::into_wit_any_array_dtype(decoded.dtype())
+                    .map_err(ExternalError::from_error)?,
+                shape: convert::usize_as_u32_slice(decoded.shape()),
+            },
+        ) {
+            Ok(dec) => match convert::from_wit_any_array(dec) {
+                Ok(dec) => decoded.assign(&dec).map_err(ExternalError::from_error),
+                Err(err) => Err(ExternalError::from_error(err)),
+            },
+            Err(err) => Err(ExternalError::new(err)),
+        }
+    }
+}
+
+impl DynCodec for ExternalCodec {
+    type Type = ExternalCodecType;
+
+    fn get_config<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let config = self
+            .codec
+            .get_config()
+            .map_err(ExternalError::new)
+            .map_err(serde::ser::Error::custom)?;
+        transcode(&mut serde_json::Deserializer::from_str(&config), serializer)
+    }
+
+    fn ty(&self) -> Self::Type {
+        ExternalCodecType {
+            ty: self.ty.ty.clone(),
+            codec_id: self.ty.codec_id.clone(),
+            schema: self.ty.schema.clone(),
+        }
+    }
+}
+
+pub struct ExternalCodecType {
+    ty: Arc<wit::registry::ExternalCodecType>,
+    codec_id: Arc<str>,
+    schema: Arc<Schema>,
+}
+
+impl DynCodecType for ExternalCodecType {
+    type Codec = ExternalCodec;
+
+    fn codec_id(&self) -> &str {
+        &*self.codec_id
+    }
+
+    fn codec_config_schema(&self) -> Schema {
+        (*self.schema).clone()
+    }
+
+    fn codec_from_config<'de, D: Deserializer<'de>>(
+        &self,
+        config: D,
+    ) -> Result<Self::Codec, D::Error> {
+        let mut config_bytes = Vec::new();
+        transcode(config, &mut serde_json::Serializer::new(&mut config_bytes))
+            .map_err(serde::de::Error::custom)?;
+        let config = String::from_utf8(config_bytes).map_err(serde::de::Error::custom)?;
+
+        let codec = self
+            .ty
+            .codec_from_config(&config)
+            .map_err(ExternalError::new)
+            .map_err(serde::de::Error::custom)?;
+
+        Ok(ExternalCodec {
+            codec,
+            ty: ExternalCodecType {
+                ty: self.ty.clone(),
+                codec_id: self.codec_id.clone(),
+                schema: self.schema.clone(),
+            },
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{msg}")]
+pub struct ExternalError {
+    msg: String,
+    source: Option<Box<Self>>,
+}
+
+impl ExternalError {
+    fn new(error: wit::types::Error) -> Self {
+        let mut root = Self {
+            msg: error.message,
+            source: None,
+        };
+
+        let mut err = &mut root;
+
+        for msg in error.chain {
+            err = &mut *err.source.insert(Box::new(Self { msg, source: None }));
+        }
+
+        root
+    }
+
+    fn from_error(err: impl std::error::Error) -> Self {
+        Self::new(convert::into_wit_error(err))
+    }
+}
+
+pub struct ExternalRegistry;
+
+impl Registry for ExternalRegistry {
+    type Error = ExternalError;
+
+    fn get_codec<'de, D: Deserializer<'de>>(
+        &self,
+        config: D,
+    ) -> Result<ErasedDynCodec, Self::Error> {
+        let mut config_bytes = Vec::new();
+        transcode(config, &mut serde_json::Serializer::new(&mut config_bytes))
+            .map_err(ExternalError::from_error)?;
+        let config = String::from_utf8(config_bytes).map_err(ExternalError::from_error)?;
+
+        let codec = wit::registry::get_codec(&config).map_err(ExternalError::new)?;
+        let ty = codec.ty();
+
+        let codec_id = ty.codec_id();
+        let schema: Schema =
+            serde_json::from_str(&ty.codec_config_schema()).map_err(ExternalError::from_error)?;
+
+        let codec = ExternalCodec {
+            codec,
+            ty: ExternalCodecType {
+                ty: std::sync::Arc::new(ty),
+                codec_id: codec_id.into(),
+                schema: std::sync::Arc::new(schema),
+            },
+        };
+
+        Ok(ErasedDynCodec::new(codec))
+    }
+}
+
+export_global! { registry: ExternalRegistry = ExternalRegistry }

--- a/crates/numcodecs-wasm-guest/src/external.rs
+++ b/crates/numcodecs-wasm-guest/src/external.rs
@@ -62,7 +62,7 @@ impl Codec for ExternalCodec {
             &wit::types::AnyArrayPrototype {
                 dtype: convert::into_wit_any_array_dtype(decoded.dtype())
                     .map_err(ExternalError::from_error)?,
-                shape: convert::usize_as_u32_slice(decoded.shape()),
+                shape: convert::into_wit_usize_vec(decoded.shape()),
             },
         ) {
             Ok(dec) => match convert::from_wit_any_array(dec) {

--- a/crates/numcodecs-wasm-guest/src/external.rs
+++ b/crates/numcodecs-wasm-guest/src/external.rs
@@ -127,6 +127,8 @@ impl DynCodecType for ExternalCodecType {
             .map_err(ExternalError::new)
             .map_err(serde::de::Error::custom)?;
 
+        // TODO: can we avoid double wrapping through the WASM boundary
+        //       ExternalCodec(WasmCodec(MyCodec))
         Ok(ExternalCodec {
             codec,
             ty: Self {

--- a/crates/numcodecs-wasm-guest/src/external.rs
+++ b/crates/numcodecs-wasm-guest/src/external.rs
@@ -180,7 +180,7 @@ impl Registry for ExternalRegistry {
             .map_err(ExternalError::from_error)?;
         let config = String::from_utf8(config_bytes).map_err(ExternalError::from_error)?;
 
-        let codec = wit::registry::get_codec(&config).map_err(ExternalError::new)?;
+        let codec = wit::registry::get_external_codec(&config).map_err(ExternalError::new)?;
         let ty = codec.ty();
 
         let codec_id = ty.codec_id();

--- a/crates/numcodecs-wasm-guest/src/external.rs
+++ b/crates/numcodecs-wasm-guest/src/external.rs
@@ -105,7 +105,7 @@ impl DynCodecType for ExternalCodecType {
     type Codec = ExternalCodec;
 
     fn codec_id(&self) -> &str {
-        &*self.codec_id
+        &self.codec_id
     }
 
     fn codec_config_schema(&self) -> Schema {
@@ -129,7 +129,7 @@ impl DynCodecType for ExternalCodecType {
 
         Ok(ExternalCodec {
             codec,
-            ty: ExternalCodecType {
+            ty: Self {
                 ty: self.ty.clone(),
                 codec_id: self.codec_id.clone(),
                 schema: self.schema.clone(),

--- a/crates/numcodecs-wasm-guest/src/lib.rs
+++ b/crates/numcodecs-wasm-guest/src/lib.rs
@@ -57,7 +57,10 @@ pub mod bindings {
 
 #[cfg(target_arch = "wasm32")]
 mod wit {
-    pub use crate::bindings::{exports::numcodecs::abc::codec, numcodecs::abc::{registry, types}};
+    pub use crate::bindings::{
+        exports::numcodecs::abc::codec,
+        numcodecs::abc::{registry, types},
+    };
 }
 
 #[macro_export]

--- a/crates/numcodecs-wasm-guest/src/lib.rs
+++ b/crates/numcodecs-wasm-guest/src/lib.rs
@@ -36,23 +36,28 @@ use ::{
 mod convert;
 
 #[cfg(target_arch = "wasm32")]
-use crate::{
-    bindings::exports::numcodecs::abc::codec as wit,
-    convert::{
-        from_wit_any_array, into_wit_any_array, into_wit_error, zeros_from_wit_any_array_prototype,
-    },
+mod external;
+
+#[cfg(target_arch = "wasm32")]
+use crate::convert::{
+    from_wit_any_array, into_wit_any_array, into_wit_error, zeros_from_wit_any_array_prototype,
 };
 
 #[doc(hidden)]
 #[expect(clippy::same_length_and_capacity)]
 pub mod bindings {
     wit_bindgen::generate!({
-        world: "numcodecs:abc/exports@0.1.1",
+        world: "numcodecs:abc/exports-with-registry@0.1.1",
         with: {
             "numcodecs:abc/codec@0.1.1": generate,
         },
         pub_export_macro: true,
     });
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wit {
+    pub use crate::bindings::{exports::numcodecs::abc::codec, numcodecs::abc::{registry, types}};
 }
 
 #[macro_export]
@@ -96,14 +101,14 @@ macro_rules! export_codec {
 
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
-impl<T: StaticCodec> wit::Guest for T {
+impl<T: StaticCodec> wit::codec::Guest for T {
     type Codec = Self;
 
     fn codec_id() -> String {
         String::from(<Self as StaticCodec>::CODEC_ID)
     }
 
-    fn codec_config_schema() -> wit::JsonSchema {
+    fn codec_config_schema() -> wit::types::JsonSchema {
         schema_for!(<Self as StaticCodec>::Config<'static>)
             .as_value()
             .to_string()
@@ -111,12 +116,16 @@ impl<T: StaticCodec> wit::Guest for T {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl<T: StaticCodec> wit::GuestCodec for T {
-    fn from_config(config: String) -> Result<wit::Codec, wit::Error> {
+impl<T: StaticCodec> wit::codec::GuestCodec for T {
+    fn from_config(config: String) -> Result<wit::codec::Codec, wit::types::Error> {
         let err = match <Self as StaticCodec>::Config::deserialize(
             &mut serde_json::Deserializer::from_str(&config),
         ) {
-            Ok(config) => return Ok(wit::Codec::new(<Self as StaticCodec>::from_config(config))),
+            Ok(config) => {
+                return Ok(wit::codec::Codec::new(<Self as StaticCodec>::from_config(
+                    config,
+                )));
+            }
             Err(err) => err,
         };
 
@@ -124,7 +133,10 @@ impl<T: StaticCodec> wit::GuestCodec for T {
         Err(into_wit_error(err))
     }
 
-    fn encode(&self, data: wit::AnyArray) -> Result<wit::AnyArray, wit::Error> {
+    fn encode(
+        &self,
+        data: wit::types::AnyArray,
+    ) -> Result<wit::types::AnyArray, wit::types::Error> {
         let data = match from_wit_any_array(data) {
             Ok(data) => data,
             Err(err) => return Err(into_wit_error(err)),
@@ -139,7 +151,10 @@ impl<T: StaticCodec> wit::GuestCodec for T {
         }
     }
 
-    fn decode(&self, encoded: wit::AnyArray) -> Result<wit::AnyArray, wit::Error> {
+    fn decode(
+        &self,
+        encoded: wit::types::AnyArray,
+    ) -> Result<wit::types::AnyArray, wit::types::Error> {
         let encoded = match from_wit_any_array(encoded) {
             Ok(encoded) => encoded,
             Err(err) => return Err(into_wit_error(err)),
@@ -156,9 +171,9 @@ impl<T: StaticCodec> wit::GuestCodec for T {
 
     fn decode_into(
         &self,
-        encoded: wit::AnyArray,
-        decoded: wit::AnyArrayPrototype,
-    ) -> Result<wit::AnyArray, wit::Error> {
+        encoded: wit::types::AnyArray,
+        decoded: wit::types::AnyArrayPrototype,
+    ) -> Result<wit::types::AnyArray, wit::types::Error> {
         let encoded = match from_wit_any_array(encoded) {
             Ok(encoded) => encoded,
             Err(err) => return Err(into_wit_error(err)),
@@ -175,7 +190,7 @@ impl<T: StaticCodec> wit::GuestCodec for T {
         }
     }
 
-    fn get_config(&self) -> Result<wit::Json, wit::Error> {
+    fn get_config(&self) -> Result<wit::types::Json, wit::types::Error> {
         match serde_json::to_string(&<Self as StaticCodec>::get_config(self)) {
             Ok(config) => Ok(config),
             Err(err) => Err(into_wit_error(err)),

--- a/crates/numcodecs-wasm-guest/src/lib.rs
+++ b/crates/numcodecs-wasm-guest/src/lib.rs
@@ -59,6 +59,8 @@ pub mod bindings {
         world: "numcodecs:abc/exports@0.1.1",
         with: {
             "numcodecs:abc/codec@0.1.1": generate,
+            // TODO: generate the separate types interface
+            "numcodecs:abc/types@0.1.1": crate::bindings::exports::numcodecs::abc::codec,
         },
         pub_export_macro: true,
         features: ["registry"],
@@ -79,13 +81,8 @@ mod wit {
     }
 
     pub mod types {
-        #[cfg(not(feature = "registry"))]
+        // TODO: use crate::bindings::numcodecs::abc::types
         pub use crate::bindings::exports::numcodecs::abc::codec::{
-            AnyArray, AnyArrayData, AnyArrayDtype, AnyArrayPrototype, Error, Json, JsonSchema,
-            Usize,
-        };
-        #[cfg(feature = "registry")]
-        pub use crate::bindings::numcodecs::abc::types::{
             AnyArray, AnyArrayData, AnyArrayDtype, AnyArrayPrototype, Error, Json, JsonSchema,
             Usize,
         };

--- a/crates/numcodecs-wasm-guest/src/lib.rs
+++ b/crates/numcodecs-wasm-guest/src/lib.rs
@@ -47,11 +47,12 @@ use crate::convert::{
 #[expect(clippy::same_length_and_capacity)]
 pub mod bindings {
     wit_bindgen::generate!({
-        world: "numcodecs:abc/exports-with-registry@0.1.1",
+        world: "numcodecs:abc/exports@0.1.1",
         with: {
             "numcodecs:abc/codec@0.1.1": generate,
         },
         pub_export_macro: true,
+        features: ["registry"],
     });
 }
 

--- a/crates/numcodecs-wasm-guest/src/lib.rs
+++ b/crates/numcodecs-wasm-guest/src/lib.rs
@@ -35,7 +35,7 @@ use ::{
 #[cfg(target_arch = "wasm32")]
 mod convert;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "registry", target_arch = "wasm32"))]
 mod external;
 
 #[cfg(target_arch = "wasm32")]
@@ -46,6 +46,15 @@ use crate::convert::{
 #[doc(hidden)]
 #[expect(clippy::same_length_and_capacity)]
 pub mod bindings {
+    #[cfg(not(feature = "registry"))]
+    wit_bindgen::generate!({
+        world: "numcodecs:abc/exports@0.1.1",
+        with: {
+            "numcodecs:abc/codec@0.1.1": generate,
+        },
+        pub_export_macro: true,
+    });
+    #[cfg(feature = "registry")]
     wit_bindgen::generate!({
         world: "numcodecs:abc/exports@0.1.1",
         with: {
@@ -58,10 +67,29 @@ pub mod bindings {
 
 #[cfg(target_arch = "wasm32")]
 mod wit {
-    pub use crate::bindings::{
-        exports::numcodecs::abc::codec,
-        numcodecs::abc::{registry, types},
-    };
+    pub mod codec {
+        pub use crate::bindings::exports::numcodecs::abc::codec::{Codec, Guest, GuestCodec};
+    }
+
+    #[cfg(feature = "registry")]
+    pub mod registry {
+        pub use crate::bindings::numcodecs::abc::registry::{
+            ExternalCodec, ExternalCodecType, get_external_codec,
+        };
+    }
+
+    pub mod types {
+        #[cfg(not(feature = "registry"))]
+        pub use crate::bindings::exports::numcodecs::abc::codec::{
+            AnyArray, AnyArrayData, AnyArrayDtype, AnyArrayPrototype, Error, Json, JsonSchema,
+            Usize,
+        };
+        #[cfg(feature = "registry")]
+        pub use crate::bindings::numcodecs::abc::types::{
+            AnyArray, AnyArrayData, AnyArrayDtype, AnyArrayPrototype, Error, Json, JsonSchema,
+            Usize,
+        };
+    }
 }
 
 #[macro_export]

--- a/crates/numcodecs-wasm-host-reproducible/src/transform/instcnt.rs
+++ b/crates/numcodecs-wasm-host-reproducible/src/transform/instcnt.rs
@@ -47,7 +47,7 @@ struct InstructionCounterInjecterReencoder {
     func_index: u32,
 }
 
-impl wasm_encoder::reencode::Reencode for InstructionCounterInjecterReencoder {
+impl reencode::Reencode for InstructionCounterInjecterReencoder {
     type Error = Error;
 
     fn global_index(&mut self, global: u32) -> Result<u32, reencode::Error<Self::Error>> {

--- a/crates/numcodecs-wasm-host-reproducible/src/transform/nan.rs
+++ b/crates/numcodecs-wasm-host-reproducible/src/transform/nan.rs
@@ -42,7 +42,7 @@ struct NaNCanonicaliserReencoder {
     function_type_indices: VecDeque<usize>,
 }
 
-impl wasm_encoder::reencode::Reencode for NaNCanonicaliserReencoder {
+impl reencode::Reencode for NaNCanonicaliserReencoder {
     type Error = Error;
 
     fn parse_type_section(

--- a/crates/numcodecs-wasm-host/src/registry.rs
+++ b/crates/numcodecs-wasm-host/src/registry.rs
@@ -127,7 +127,8 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]external-codec.encode", external_codec_encode)?;
+    numcodecs_registry_instance
+        .define_func("[method]external-codec.encode", external_codec_encode)?;
 
     let my_any_array_result = any_array_result.clone();
     let my_numcodecs_types_error_record = numcodecs_types_error_record.clone();
@@ -176,7 +177,8 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]external-codec.decode", external_codec_decode)?;
+    numcodecs_registry_instance
+        .define_func("[method]external-codec.decode", external_codec_decode)?;
 
     let any_array_prototype_record = WasmCodec::any_array_prototype_ty().clone();
 
@@ -237,15 +239,21 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance
-        .define_func("[method]external-codec.decode-into", external_codec_decode_into)?;
+    numcodecs_registry_instance.define_func(
+        "[method]external-codec.decode-into",
+        external_codec_decode_into,
+    )?;
 
     let my_numcodecs_registry_codec_resource = numcodecs_registry_external_codec_resource.clone();
     let external_codec_clone = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
-            [ValueType::Borrow(numcodecs_registry_external_codec_resource.clone())],
-            [ValueType::Own(numcodecs_registry_external_codec_resource.clone())],
+            [ValueType::Borrow(
+                numcodecs_registry_external_codec_resource.clone(),
+            )],
+            [ValueType::Own(
+                numcodecs_registry_external_codec_resource.clone(),
+            )],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(codec)] = args else {
@@ -275,7 +283,8 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]external-codec.clone", external_codec_clone)?;
+    numcodecs_registry_instance
+        .define_func("[method]external-codec.clone", external_codec_clone)?;
 
     let string_result = ResultType::new(
         Some(ValueType::String),
@@ -286,7 +295,9 @@ pub fn add_registry_to_linker(
     let external_codec_get_config = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
-            [ValueType::Borrow(numcodecs_registry_external_codec_resource.clone())],
+            [ValueType::Borrow(
+                numcodecs_registry_external_codec_resource.clone(),
+            )],
             [ValueType::Result(string_result.clone())],
         ),
         move |ctx, args, results| {
@@ -326,23 +337,26 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance
-        .define_func("[method]external-codec.get-config", external_codec_get_config)?;
+    numcodecs_registry_instance.define_func(
+        "[method]external-codec.get-config",
+        external_codec_get_config,
+    )?;
 
-    let my_numcodecs_registry_codec_type_resource = numcodecs_registry_external_codec_type_resource.clone();
+    let my_numcodecs_registry_codec_type_resource =
+        numcodecs_registry_external_codec_type_resource.clone();
     let external_codec_ty = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
-            [ValueType::Borrow(numcodecs_registry_external_codec_resource.clone())],
+            [ValueType::Borrow(
+                numcodecs_registry_external_codec_resource.clone(),
+            )],
             [ValueType::Own(
                 numcodecs_registry_external_codec_type_resource.clone(),
             )],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(codec)] = args else {
-                anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]external-codec.ty arguments"
-                );
+                anyhow::bail!("invalid numcodecs:abc/registry#[method]external-codec.ty arguments");
             };
 
             let [result] = results else {
@@ -395,8 +409,10 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance
-        .define_func("[method]external-codec-type.codec-id", external_codec_type_id)?;
+    numcodecs_registry_instance.define_func(
+        "[method]external-codec-type.codec-id",
+        external_codec_type_id,
+    )?;
 
     let external_codec_type_schema = Func::new(
         ctx.as_context_mut(),
@@ -433,7 +449,9 @@ pub fn add_registry_to_linker(
     )?;
 
     let codec_result = ResultType::new(
-        Some(ValueType::Own(numcodecs_registry_external_codec_resource.clone())),
+        Some(ValueType::Own(
+            numcodecs_registry_external_codec_resource.clone(),
+        )),
         Some(ValueType::Record(numcodecs_types_error_record.clone())),
     );
 

--- a/crates/numcodecs-wasm-host/src/registry.rs
+++ b/crates/numcodecs-wasm-host/src/registry.rs
@@ -39,10 +39,10 @@ pub fn add_registry_to_linker(
     let numcodecs_registry_instance =
         linker.define_instance(numcodecs_registry_interface.clone())?;
 
-    let numcodecs_registry_codec_resource = ResourceType::with_destructor(
+    let numcodecs_registry_external_codec_resource = ResourceType::with_destructor(
         ctx.as_context_mut(),
         Some(TypeIdentifier::new(
-            "erased-dyn-codec",
+            "external-codec",
             Some(numcodecs_registry_interface.clone()),
         )),
         |_ctx, codec: ErasedDynCodec| {
@@ -52,14 +52,14 @@ pub fn add_registry_to_linker(
     )?;
 
     numcodecs_registry_instance.define_resource(
-        "erased-dyn-codec",
-        numcodecs_registry_codec_resource.clone(),
+        "external-codec",
+        numcodecs_registry_external_codec_resource.clone(),
     )?;
 
-    let numcodecs_registry_codec_type_resource = ResourceType::with_destructor(
+    let numcodecs_registry_external_codec_type_resource = ResourceType::with_destructor(
         ctx.as_context_mut(),
         Some(TypeIdentifier::new(
-            "erased-dyn-codec-type",
+            "external-codec-type",
             Some(numcodecs_registry_interface.clone()),
         )),
         |_ctx, codec_ty: ErasedDynCodecType| {
@@ -69,8 +69,8 @@ pub fn add_registry_to_linker(
     )?;
 
     numcodecs_registry_instance.define_resource(
-        "erased-dyn-codec-type",
-        numcodecs_registry_codec_type_resource.clone(),
+        "external-codec-type",
+        numcodecs_registry_external_codec_type_resource.clone(),
     )?;
 
     let any_array_record = WasmCodec::any_array_ty().clone();
@@ -82,11 +82,11 @@ pub fn add_registry_to_linker(
 
     let my_any_array_result = any_array_result.clone();
     let my_numcodecs_types_error_record = numcodecs_types_error_record.clone();
-    let codec_encode = Func::new(
+    let external_codec_encode = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
             [
-                ValueType::Borrow(numcodecs_registry_codec_resource.clone()),
+                ValueType::Borrow(numcodecs_registry_external_codec_resource.clone()),
                 ValueType::Record(any_array_record.clone()),
             ],
             [ValueType::Result(any_array_result.clone())],
@@ -94,13 +94,13 @@ pub fn add_registry_to_linker(
         move |ctx, args, results| {
             let [Value::Borrow(codec), Value::Record(data)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.encode arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec.encode arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.encode results"
+                    "invalid numcodecs:abc/registry#[method]external-codec.encode results"
                 );
             };
 
@@ -127,15 +127,15 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]erased-dyn-codec.encode", codec_encode)?;
+    numcodecs_registry_instance.define_func("[method]external-codec.encode", external_codec_encode)?;
 
     let my_any_array_result = any_array_result.clone();
     let my_numcodecs_types_error_record = numcodecs_types_error_record.clone();
-    let codec_decode = Func::new(
+    let external_codec_decode = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
             [
-                ValueType::Borrow(numcodecs_registry_codec_resource.clone()),
+                ValueType::Borrow(numcodecs_registry_external_codec_resource.clone()),
                 ValueType::Record(any_array_record.clone()),
             ],
             [ValueType::Result(any_array_result.clone())],
@@ -143,13 +143,13 @@ pub fn add_registry_to_linker(
         move |ctx, args, results| {
             let [Value::Borrow(codec), Value::Record(encoded)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.decode arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec.decode arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.decode results"
+                    "invalid numcodecs:abc/registry#[method]external-codec.decode results"
                 );
             };
 
@@ -176,17 +176,17 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]erased-dyn-codec.decode", codec_decode)?;
+    numcodecs_registry_instance.define_func("[method]external-codec.decode", external_codec_decode)?;
 
     let any_array_prototype_record = WasmCodec::any_array_prototype_ty().clone();
 
     let my_any_array_result = any_array_result.clone();
     let my_numcodecs_types_error_record = numcodecs_types_error_record.clone();
-    let codec_decode_into = Func::new(
+    let external_codec_decode_into = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
             [
-                ValueType::Borrow(numcodecs_registry_codec_resource.clone()),
+                ValueType::Borrow(numcodecs_registry_external_codec_resource.clone()),
                 ValueType::Record(any_array_record),
                 ValueType::Record(any_array_prototype_record),
             ],
@@ -200,13 +200,13 @@ pub fn add_registry_to_linker(
             ] = args
             else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.decode-into arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec.decode-into arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.decode-into results"
+                    "invalid numcodecs:abc/registry#[method]external-codec.decode-into results"
                 );
             };
 
@@ -238,25 +238,25 @@ pub fn add_registry_to_linker(
         },
     );
     numcodecs_registry_instance
-        .define_func("[method]erased-dyn-codec.decode-into", codec_decode_into)?;
+        .define_func("[method]external-codec.decode-into", external_codec_decode_into)?;
 
-    let my_numcodecs_registry_codec_resource = numcodecs_registry_codec_resource.clone();
-    let codec_clone = Func::new(
+    let my_numcodecs_registry_codec_resource = numcodecs_registry_external_codec_resource.clone();
+    let external_codec_clone = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
-            [ValueType::Borrow(numcodecs_registry_codec_resource.clone())],
-            [ValueType::Own(numcodecs_registry_codec_resource.clone())],
+            [ValueType::Borrow(numcodecs_registry_external_codec_resource.clone())],
+            [ValueType::Own(numcodecs_registry_external_codec_resource.clone())],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(codec)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.clone arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec.clone arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.clone results"
+                    "invalid numcodecs:abc/registry#[method]external-codec.clone results"
                 );
             };
 
@@ -275,7 +275,7 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]erased-dyn-codec.clone", codec_clone)?;
+    numcodecs_registry_instance.define_func("[method]external-codec.clone", external_codec_clone)?;
 
     let string_result = ResultType::new(
         Some(ValueType::String),
@@ -283,22 +283,22 @@ pub fn add_registry_to_linker(
     );
 
     let my_numcodecs_types_error_record = numcodecs_types_error_record.clone();
-    let codec_get_config = Func::new(
+    let external_codec_get_config = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
-            [ValueType::Borrow(numcodecs_registry_codec_resource.clone())],
+            [ValueType::Borrow(numcodecs_registry_external_codec_resource.clone())],
             [ValueType::Result(string_result.clone())],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(codec)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.get-config arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec.get-config arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.get-config results"
+                    "invalid numcodecs:abc/registry#[method]external-codec.get-config results"
                 );
             };
 
@@ -327,26 +327,26 @@ pub fn add_registry_to_linker(
         },
     );
     numcodecs_registry_instance
-        .define_func("[method]erased-dyn-codec.get-config", codec_get_config)?;
+        .define_func("[method]external-codec.get-config", external_codec_get_config)?;
 
-    let my_numcodecs_registry_codec_type_resource = numcodecs_registry_codec_type_resource.clone();
-    let codec_ty = Func::new(
+    let my_numcodecs_registry_codec_type_resource = numcodecs_registry_external_codec_type_resource.clone();
+    let external_codec_ty = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
-            [ValueType::Borrow(numcodecs_registry_codec_resource.clone())],
+            [ValueType::Borrow(numcodecs_registry_external_codec_resource.clone())],
             [ValueType::Own(
-                numcodecs_registry_codec_type_resource.clone(),
+                numcodecs_registry_external_codec_type_resource.clone(),
             )],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(codec)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec.ty arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec.ty arguments"
                 );
             };
 
             let [result] = results else {
-                anyhow::bail!("invalid numcodecs:abc/registry#[method]erased-dyn-codec.ty results");
+                anyhow::bail!("invalid numcodecs:abc/registry#[method]external-codec.ty results");
             };
 
             let ty = {
@@ -364,26 +364,26 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("[method]erased-dyn-codec.ty", codec_ty)?;
+    numcodecs_registry_instance.define_func("[method]external-codec.ty", external_codec_ty)?;
 
-    let codec_type_id = Func::new(
+    let external_codec_type_id = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
             [ValueType::Borrow(
-                numcodecs_registry_codec_type_resource.clone(),
+                numcodecs_registry_external_codec_type_resource.clone(),
             )],
             [ValueType::String],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(ty)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec-type.codec-id arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec-type.codec-id arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codectype.codec-id results"
+                    "invalid numcodecs:abc/registry#[method]external-codectype.codec-id results"
                 );
             };
 
@@ -396,26 +396,26 @@ pub fn add_registry_to_linker(
         },
     );
     numcodecs_registry_instance
-        .define_func("[method]erased-dyn-codec-type.codec-id", codec_type_id)?;
+        .define_func("[method]external-codec-type.codec-id", external_codec_type_id)?;
 
-    let codec_type_schema = Func::new(
+    let external_codec_type_schema = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
             [ValueType::Borrow(
-                numcodecs_registry_codec_type_resource.clone(),
+                numcodecs_registry_external_codec_type_resource.clone(),
             )],
             [ValueType::String],
         ),
         move |ctx, args, results| {
             let [Value::Borrow(ty)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec-type.codec-config-schema arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec-type.codec-config-schema arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codectype.codec-config-schema results"
+                    "invalid numcodecs:abc/registry#[method]external-codectype.codec-config-schema results"
                 );
             };
 
@@ -428,23 +428,23 @@ pub fn add_registry_to_linker(
         },
     );
     numcodecs_registry_instance.define_func(
-        "[method]erased-dyn-codec-type.codec-config-schema",
-        codec_type_schema,
+        "[method]external-codec-type.codec-config-schema",
+        external_codec_type_schema,
     )?;
 
     let codec_result = ResultType::new(
-        Some(ValueType::Own(numcodecs_registry_codec_resource.clone())),
+        Some(ValueType::Own(numcodecs_registry_external_codec_resource.clone())),
         Some(ValueType::Record(numcodecs_types_error_record.clone())),
     );
 
-    let my_numcodecs_registry_codec_resource = numcodecs_registry_codec_resource.clone();
+    let my_numcodecs_registry_codec_resource = numcodecs_registry_external_codec_resource.clone();
     let my_numcodecs_types_error_record = numcodecs_types_error_record.clone();
     let my_codec_result = codec_result.clone();
-    let codec_from_config = Func::new(
+    let external_codec_from_config = Func::new(
         ctx.as_context_mut(),
         FuncType::new(
             [
-                ValueType::Borrow(numcodecs_registry_codec_type_resource),
+                ValueType::Borrow(numcodecs_registry_external_codec_type_resource),
                 ValueType::String,
             ],
             [ValueType::Result(my_codec_result.clone())],
@@ -452,13 +452,13 @@ pub fn add_registry_to_linker(
         move |ctx, args, results| {
             let [Value::Borrow(ty), Value::String(config)] = args else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codec-type.codec-from-config arguments"
+                    "invalid numcodecs:abc/registry#[method]external-codec-type.codec-from-config arguments"
                 );
             };
 
             let [result] = results else {
                 anyhow::bail!(
-                    "invalid numcodecs:abc/registry#[method]erased-dyn-codectype.codec-from-config results"
+                    "invalid numcodecs:abc/registry#[method]external-codectype.codec-from-config results"
                 );
             };
 
@@ -486,14 +486,14 @@ pub fn add_registry_to_linker(
         },
     );
     numcodecs_registry_instance.define_func(
-        "[method]erased-dyn-codec-type.codec-from-config",
-        codec_from_config,
+        "[method]external-codec-type.codec-from-config",
+        external_codec_from_config,
     )?;
 
-    let my_numcodecs_registry_codec_resource = numcodecs_registry_codec_resource;
+    let my_numcodecs_registry_codec_resource = numcodecs_registry_external_codec_resource;
     let my_numcodecs_types_error_record = numcodecs_types_error_record;
     let my_codec_result = codec_result;
-    let get_codec = Func::new(
+    let get_external_codec = Func::new(
         ctx,
         FuncType::new(
             [ValueType::String],
@@ -501,11 +501,11 @@ pub fn add_registry_to_linker(
         ),
         move |ctx, args, results| {
             let [Value::String(config)] = args else {
-                anyhow::bail!("invalid numcodecs:abc/registry#get-codec arguments");
+                anyhow::bail!("invalid numcodecs:abc/registry#get-external-codec arguments");
             };
 
             let [result] = results else {
-                anyhow::bail!("invalid numcodecs:abc/registry#get-codec results");
+                anyhow::bail!("invalid numcodecs:abc/registry#get-external-codec results");
             };
 
             let res = match registry.get_codec(&mut serde_json::Deserializer::from_str(config)) {
@@ -525,7 +525,7 @@ pub fn add_registry_to_linker(
             Ok(())
         },
     );
-    numcodecs_registry_instance.define_func("get-codec", get_codec)?;
+    numcodecs_registry_instance.define_func("get-external-codec", get_external_codec)?;
 
     Ok(())
 }

--- a/crates/numcodecs/Cargo.toml
+++ b/crates/numcodecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs"
-version = "0.3.1"
+version = "0.3.2"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/crates/numcodecs/src/erased.rs
+++ b/crates/numcodecs/src/erased.rs
@@ -13,8 +13,12 @@ pub struct ErasedError {
 impl ErasedError {
     /// Erase the type information of the concrete `err`or.
     pub fn new<T: 'static + Error + Send + Sync>(err: T) -> Self {
-        Self {
-            error: Box::new(err),
+        let err: Box<dyn 'static + Error + Send + Sync> = Box::new(err);
+
+        // avoid double-erasing Self(Self(...))
+        match err.downcast::<Self>() {
+            Ok(err) => *err,
+            Err(err) => Self { error: err },
         }
     }
 }
@@ -45,9 +49,18 @@ pub struct ErasedDynCodec {
 impl ErasedDynCodec {
     /// Erase the type information of the concrete `codec`.
     pub fn new<T: DynCodec>(codec: T) -> Self {
-        Self {
-            codec: Box::new(codec),
+        let codec: Box<dyn ErasedDynCodecDispatch> = Box::new(codec);
+
+        // avoid double-erasing Self(Self(...))
+        if codec.erased_as_any().is::<Self>() {
+            let raw = Box::into_raw(codec);
+            #[expect(unsafe_code, clippy::cast_ptr_alignment)]
+            // SAFETY: we have checked that self.codec is of type Self
+            let codec = unsafe { Box::from_raw(raw.cast::<Self>()) };
+            return *codec;
         }
+
+        Self { codec }
     }
 
     /// Try to downcast into a concretely-typed codec.
@@ -145,7 +158,18 @@ pub struct ErasedDynCodecType {
 impl ErasedDynCodecType {
     /// Erase the type information of the concrete codec `ty`pe.
     pub fn new<T: DynCodecType>(ty: T) -> Self {
-        Self { ty: Box::new(ty) }
+        let ty: Box<dyn ErasedDynCodecTypeDispatch> = Box::new(ty);
+
+        // avoid double-erasing Self(Self(...))
+        if ty.erased_as_any().is::<Self>() {
+            let raw = Box::into_raw(ty);
+            #[expect(unsafe_code, clippy::cast_ptr_alignment)]
+            // SAFETY: we have checked that self.codec is of type Self
+            let ty = unsafe { Box::from_raw(raw.cast::<Self>()) };
+            return *ty;
+        }
+
+        Self { ty }
     }
 
     /// Try to downcast into a concretely-typed codec type.

--- a/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
+++ b/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
@@ -98,6 +98,10 @@ for c in (repo_path / "codecs").iterdir():
         with np.open("w") as f:
             f.write(c)
 
+    wasm_features = toml.load(codec_crate_path / "Cargo.toml")["package"]["metadata"][
+        "numcodecs-wasm"
+    ].get("wasm-features", [])
+
     subprocess.run(
         shlex.split(
             "cargo run -p numcodecs-wasm-builder --"
@@ -108,6 +112,7 @@ for c in (repo_path / "codecs").iterdir():
             + (" --local" if args.local else "")
             + (" --debug" if args.debug else "")
             + (" --verbose" if args.verbose else "")
+            + "".join(f" --wasm-features {feature}" for feature in wasm_features)
         ),
         check=True,
     )

--- a/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
+++ b/py/numcodecs-wasm-materialize/src/numcodecs_wasm_materialize/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import re
 import shlex
 import shutil
@@ -33,6 +34,11 @@ parser.add_argument(
     "--verbose",
     action="store_true",
     help="enable verbose logging while compiling the codec",
+)
+parser.add_argument(
+    "--numcodecs-wasm-wheel",
+    type=Path,
+    help="pre-install a specific numcodecs_wasm-*.whl file",
 )
 args = parser.parse_args()
 
@@ -89,8 +95,8 @@ for c in (repo_path / "codecs").iterdir():
         for t, r in templates.items():
             c = c.replace(f"%{t}%", r)
 
-        for l in c.splitlines():
-            for m in template_pattern.finditer(l):
+        for line in c.splitlines():
+            for m in template_pattern.finditer(line):
                 raise Exception(f"unknown template {m.group(0)}")
 
         np.parent.mkdir(parents=True, exist_ok=True)
@@ -117,32 +123,43 @@ for c in (repo_path / "codecs").iterdir():
         check=True,
     )
 
+    shutil.rmtree(staging_path / ".venv", ignore_errors=True)
     subprocess.run(
-        shlex.split("uv sync"),
+        shlex.split("uv venv"),
         check=True,
         cwd=staging_path,
     )
+    if args.numcodecs_wasm_wheel is not None:
+        subprocess.run(
+            shlex.split(f"uv pip install {args.numcodecs_wasm_wheel.resolve()}"),
+            check=True,
+            cwd=staging_path,
+            env={**os.environ, "VIRTUAL_ENV": str(staging_path / ".venv")},
+        )
     subprocess.run(
         shlex.split("uv pip install ."),
         check=True,
         cwd=staging_path,
+        env={**os.environ, "VIRTUAL_ENV": str(staging_path / ".venv")},
     )
     subprocess.run(
         shlex.split(
-            f"uv run python3 {Path(__file__).parent / 'stub.py'} "
+            f"uv run --no-sync python3 {Path(__file__).parent / 'stub.py'} "
             + f"{'numcodecs_wasm_' + templates['package_suffix']} src"
         ),
         check=True,
         cwd=staging_path,
+        env={**os.environ, "VIRTUAL_ENV": str(staging_path / ".venv")},
     )
     subprocess.run(
         shlex.split(
-            f'uv run python3 -c "from {"numcodecs_wasm_" + templates["package_suffix"]} '
+            f'uv run --no-sync python3 -c "from {"numcodecs_wasm_" + templates["package_suffix"]} '
             + f"import {templates['CodecName']} as Codec; "
             + f'assert Codec.codec_id == {templates["codec-id"]!r}, Codec.codec_id"'
         ),
         check=True,
         cwd=staging_path,
+        env={**os.environ, "VIRTUAL_ENV": str(staging_path / ".venv")},
     )
     shutil.rmtree(staging_path / ".venv", ignore_errors=True)
 

--- a/py/numcodecs-wasm/Cargo.toml
+++ b/py/numcodecs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numcodecs-wasm"
-version = "0.2.4+wasi0.2.6"
+version = "0.2.5+wasi0.2.6"
 edition = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/py/numcodecs-wasm/pyproject.toml
+++ b/py/numcodecs-wasm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "numcodecs_wasm"
-version = "0.2.4" # wasi 0.2.6
+version = "0.2.5" # wasi 0.2.6
 description = "numcodecs compression for codecs compiled to WebAssembly"
 
 authors = [{ name = "Juniper Tyree", email = "juniper.tyree@helsinki.fi" }]

--- a/wit/codecs.wit
+++ b/wit/codecs.wit
@@ -1,10 +1,54 @@
 package numcodecs:abc@0.1.1;
 
 interface codec {
-    use types.{
-        any-array, any-array-prototype, any-array-data, any-array-dtype, error,
-        json, json-schema, usize,
-    };
+    // BEGIN TODO: replace by use types.{..} in the v0.2.0
+    type json = string;
+    type json-schema = json;
+    type usize = u32;
+
+    record any-array {
+        data: any-array-data,
+        shape: list<usize>,
+    }
+
+    @since(version = 0.1.1)
+    record any-array-prototype {
+        dtype: any-array-dtype,
+        shape: list<usize>,
+    }
+
+    variant any-array-data {
+        %u8(list<u8>),
+        %u16(list<u16>),
+        %u32(list<u32>),
+        %u64(list<u64>),
+        i8(list<s8>),
+        i16(list<s16>),
+        i32(list<s32>),
+        i64(list<s64>),
+        %f32(list<f32>),
+        %f64(list<f64>),
+    }
+
+    @since(version = 0.1.1)
+    enum any-array-dtype {
+        %u8,
+        %u16,
+        %u32,
+        %u64,
+        i8,
+        i16,
+        i32,
+        i64,
+        %f32,
+        %f64,
+    }
+
+    record error {
+        message: string,
+        chain: list<string>,
+    }
+    // END TODO: replace by use types.{..} in the v0.2.0
 
     resource codec {
         from-config: static func(config: json) -> result<codec, error>;

--- a/wit/registry.wit
+++ b/wit/registry.wit
@@ -12,7 +12,6 @@ interface registry {
 
         decode: func(encoded: any-array) -> result<any-array, error>;
 
-        @since(version = 0.1.1)
         decode-into: func(encoded: any-array, decoded: any-array-prototype) -> result<any-array, error>;
 
         clone: func() -> external-codec;

--- a/wit/registry.wit
+++ b/wit/registry.wit
@@ -1,12 +1,14 @@
 package numcodecs:abc@0.1.1;
 
-@since(version = 0.1.1)
+@unstable(feature = registry)
 interface registry {
+    @unstable(feature = registry)
     use types.{
         any-array, any-array-prototype, any-array-data, any-array-dtype, error,
         json, json-schema, usize,
     };
 
+    @unstable(feature = registry)
     resource external-codec {
         encode: func(data: any-array) -> result<any-array, error>;
 
@@ -21,6 +23,7 @@ interface registry {
         ty: func() -> external-codec-type;
     }
 
+    @unstable(feature = registry)
     resource external-codec-type {
         codec-id: func() -> string;
 
@@ -29,5 +32,6 @@ interface registry {
         codec-from-config: func(config: json) -> result<external-codec, error>;
     }
 
+    @unstable(feature = registry)
     get-external-codec: func(config: json) -> result<external-codec, error>;
 }

--- a/wit/registry.wit
+++ b/wit/registry.wit
@@ -1,14 +1,13 @@
 package numcodecs:abc@0.1.1;
 
-interface codec {
+@since(version = 0.1.1)
+interface registry {
     use types.{
         any-array, any-array-prototype, any-array-data, any-array-dtype, error,
         json, json-schema, usize,
     };
 
-    resource codec {
-        from-config: static func(config: json) -> result<codec, error>;
-
+    resource external-codec {
         encode: func(data: any-array) -> result<any-array, error>;
 
         decode: func(encoded: any-array) -> result<any-array, error>;
@@ -16,10 +15,20 @@ interface codec {
         @since(version = 0.1.1)
         decode-into: func(encoded: any-array, decoded: any-array-prototype) -> result<any-array, error>;
 
+        clone: func() -> external-codec;
+
         get-config: func() -> result<json, error>;
+
+        ty: func() -> external-codec-type;
     }
 
-    codec-id: func() -> string;
+    resource external-codec-type {
+        codec-id: func() -> string;
 
-    codec-config-schema: func() -> json-schema;
+        codec-config-schema: func() -> json-schema;
+
+        codec-from-config: func(config: json) -> result<external-codec, error>;
+    }
+
+    get-external-codec: func(config: json) -> result<external-codec, error>;
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,6 +1,5 @@
 package numcodecs:abc@0.1.1;
 
-@since(version = 0.1.1)
 interface types {
     type json = string;
     type json-schema = json;

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,0 +1,51 @@
+package numcodecs:abc@0.1.1;
+
+@since(version = 0.1.1)
+interface types {
+    type json = string;
+    type json-schema = json;
+    type usize = u32;
+
+    record any-array {
+        data: any-array-data,
+        shape: list<usize>,
+    }
+
+    @since(version = 0.1.1)
+    record any-array-prototype {
+        dtype: any-array-dtype,
+        shape: list<usize>,
+    }
+
+    variant any-array-data {
+        %u8(list<u8>),
+        %u16(list<u16>),
+        %u32(list<u32>),
+        %u64(list<u64>),
+        i8(list<s8>),
+        i16(list<s16>),
+        i32(list<s32>),
+        i64(list<s64>),
+        %f32(list<f32>),
+        %f64(list<f64>),
+    }
+
+    @since(version = 0.1.1)
+    enum any-array-dtype {
+        %u8,
+        %u16,
+        %u32,
+        %u64,
+        i8,
+        i16,
+        i32,
+        i64,
+        %f32,
+        %f64,
+    }
+
+    record error {
+        message: string,
+        chain: list<string>,
+    }
+}

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,21 +1,35 @@
 package numcodecs:abc@0.1.1;
 
+@unstable(feature = registry)
 interface types {
+    @unstable(feature = registry)
+    // @since(version = 0.1.0)
     type json = string;
+    
+    @unstable(feature = registry)
+    // @since(version = 0.1.0)
     type json-schema = json;
+    
+    @unstable(feature = registry)
+    // @since(version = 0.1.0)
     type usize = u32;
 
+    @unstable(feature = registry)
+    // @since(version = 0.1.0)
     record any-array {
         data: any-array-data,
         shape: list<usize>,
     }
 
-    @since(version = 0.1.1)
+    @unstable(feature = registry)
+    // @since(version = 0.1.1)
     record any-array-prototype {
         dtype: any-array-dtype,
         shape: list<usize>,
     }
 
+    @unstable(feature = registry)
+    // @since(version = 0.1.0)
     variant any-array-data {
         %u8(list<u8>),
         %u16(list<u16>),
@@ -29,7 +43,8 @@ interface types {
         %f64(list<f64>),
     }
 
-    @since(version = 0.1.1)
+    @unstable(feature = registry)
+    // @since(version = 0.1.1)
     enum any-array-dtype {
         %u8,
         %u16,
@@ -43,6 +58,8 @@ interface types {
         %f64,
     }
 
+    @unstable(feature = registry)
+    // @since(version = 0.1.0)
     record error {
         message: string,
         chain: list<string>,

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -2,20 +2,12 @@ package numcodecs:abc@0.1.1;
 
 world imports {
     import codec;
+    @unstable(feature = registry)
+    export registry;
 }
 
 world exports {
     export codec;
-}
-
-@since(version = 0.1.1)
-world imports-with-registry {
-    import codec;
-    export registry;
-}
-
-@since(version = 0.1.1)
-world exports-with-registry {
-    export codec;
+    @unstable(feature = registry)
     import registry;
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -7,3 +7,15 @@ world imports {
 world exports {
     export codec;
 }
+
+@since(version = 0.1.1)
+world imports-with-registry {
+    import codec;
+    export registry;
+}
+
+@since(version = 0.1.1)
+world exports-with-registry {
+    export codec;
+    import registry;
+}


### PR DESCRIPTION
- [ ] We still need to later decide on how to describe, inspect, and map over meta codecs and sync up with numcodecs-combinators: https://gist.github.com/juntyr/8beb9f34928b6192c75e6d27e40ab944